### PR TITLE
Implement cache poisoning if error occurs during resolution stage

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
         condition: service_healthy
       minio:
         condition: service_healthy
-    image: ghcr.io/sneaksanddata/nexus:1.1.5
+    image: ghcr.io/sneaksanddata/nexus:1.1.7
     volumes:
       - ./test-resources/kubecfg/controller:/opt/kubecfg/controller
       - ./test-resources/kubecfg/shards:/opt/kubecfg/shards
@@ -69,7 +69,7 @@ services:
     depends_on:
       scylla:
         condition: service_healthy
-    image: ghcr.io/sneaksanddata/nexus-receiver:1.1.1
+    image: ghcr.io/sneaksanddata/nexus-receiver:1.1.2
     volumes:
       - ./test-resources/kubecfg/shards/kind-nexus-shard-0.kubeconfig:/opt/kubecfg/cluster
     environment:

--- a/nexus_client_sdk/models/scheduler.py
+++ b/nexus_client_sdk/models/scheduler.py
@@ -323,7 +323,7 @@ class RequestMetadata(PySdkType):
             content_hash=result.content_hash.decode() if result.content_hash else None,
             job_uid=result.job_uid.decode() if result.job_uid else None,
             last_modified=result.last_modified.decode() if result.last_modified else None,
-            lifecycle_stage=result.lifecycle_stage,
+            lifecycle_stage=result.lifecycle_stage.decode() if result.lifecycle_stage else None,
             parent_job=result.parent_job.decode() if result.parent_job else None,
             payload_uri=result.payload_uri.decode() if result.payload_uri else None,
             payload_valid_for=result.payload_valid_for.decode() if result.payload_valid_for else None,

--- a/nexus_client_sdk/nexus/abstractions/algrorithm_cache.py
+++ b/nexus_client_sdk/nexus/abstractions/algrorithm_cache.py
@@ -65,7 +65,7 @@ class InputCache:
         self,
         *readers_or_processors: InputObject[TPayload, TResult],
         **kwargs,
-    ) -> dict[str, TResult]:
+    ) -> dict[str, TResult | None]:
         """
         Concurrently resolve `data` property of all readers by invoking their `read` method.
         """
@@ -78,10 +78,12 @@ class InputCache:
             return completed_task.result()
 
         async def _execute(nexus_input: InputObject) -> TResult:
+            result: TResult | None = None
             async with nexus_input as instance:
-                result = await nexus_input.process(**kwargs)
-
-            self._cache[instance.cache_key()] = result
+                try:
+                    result = await nexus_input.process(**kwargs)
+                finally:
+                    self._cache[instance.cache_key()] = result
 
             return result
 

--- a/nexus_client_sdk/nexus/core/app_core.py
+++ b/nexus_client_sdk/nexus/core/app_core.py
@@ -503,12 +503,12 @@ class Nexus:
                             else:
                                 metrics_provider.increment("telemetry_reports_succeeded")
                     else:
-                        root_logger.warning(
-                            "Skipping user telemetry recording as the run {run_id} has failed",
-                            run_id=self._run_args.request_id,
-                        )
+                        root_logger.info("No post processing tasks were defined for this run")
                 else:
-                    root_logger.info("No post processing tasks were defined for this run.")
+                    root_logger.warning(
+                        "Skipping user telemetry recording as the run {run_id} has failed",
+                        run_id=self._run_args.request_id,
+                    )
 
             # dispose of QES instance gracefully as it might hold open connections
             qes = self._injector.get(QueryEnabledStore)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,3 +100,13 @@ def payloads() -> list[tuple[str, str]]:
         generate_payload_url(upload_path, payload, S3StorageClient.for_storage_path(upload_path.to_hdfs_path()))
         for payload in generated
     ]
+
+
+def negative_z_payload() -> tuple[str, str]:
+    upload_path = S3Path(bucket="nexus", path="units")
+
+    return generate_payload_url(
+        upload_path,
+        TestAlgorithmPayload(x=[1, 2, 3], y=[4, 5, 6], z=[0, -1, 10]),
+        S3StorageClient.for_storage_path(upload_path.to_hdfs_path()),
+    )

--- a/tests/sample_algorithm/sample_main.py
+++ b/tests/sample_algorithm/sample_main.py
@@ -1,6 +1,6 @@
 import math
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, final
 
 import pandas
 import polars
@@ -18,6 +18,7 @@ from nexus_client_sdk.nexus.abstractions.socket_provider import (
 from nexus_client_sdk.nexus.core.app_core import Nexus
 from nexus_client_sdk.nexus.algorithms import MinimalisticAlgorithm
 from nexus_client_sdk.nexus.core.serializers import TelemetrySerializer
+from nexus_client_sdk.nexus.exceptions import FatalNexusError
 from nexus_client_sdk.nexus.input import InputReader, InputProcessor
 from nexus_client_sdk.nexus.input.command_line import NexusDefaultArguments
 
@@ -27,6 +28,15 @@ from nexus_client_sdk.nexus.telemetry.user_telemetry_recorder import (
     UserTelemetryPathSegment,
 )
 from tests.conftest import TestAlgorithmPayload, TestAlgorithmConfiguration
+
+
+@final
+class NegativeZError(FatalNexusError):
+    def __init__(self):
+        super().__init__()
+
+    def __str__(self) -> str:
+        return "Z-axis contains a negative value"
 
 
 class XYReader(InputReader[TestAlgorithmPayload, pandas.DataFrame]):
@@ -82,6 +92,9 @@ class ZReader(InputReader[TestAlgorithmPayload, pandas.DataFrame]):
         )
 
     async def _read_input(self, **_) -> pandas.DataFrame:
+        # negative value should abort the run and be handled accordingly
+        if any([v < 0 for v in self._payload.z]):
+            raise NegativeZError()
         return pandas.DataFrame({"z": self._payload.z})
 
 

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -9,9 +9,10 @@ import requests
 from cassandra.cluster import Session
 
 from nexus_client_sdk.clients.nexus_scheduler_client import NexusSchedulerClient
+from nexus_client_sdk.models.scheduler import RequestLifeCycleStage
 from nexus_client_sdk.nexus.input.command_line import NexusDefaultArguments
-from tests.conftest import payloads
-from tests.sample_algorithm.sample_main import main as sample_algorithm_main
+from tests.conftest import payloads, negative_z_payload
+from tests.sample_algorithm.sample_main import main as sample_algorithm_main, NegativeZError
 
 os.environ["PROTEUS__AWS_REGION"] = "us-east-1"
 os.environ["PROTEUS__AWS_ENDPOINT"] = "http://localhost:9000"
@@ -41,3 +42,22 @@ async def test_sdk_run(test_args: NexusDefaultArguments, scheduler: NexusSchedul
     result = json.loads(requests.get(scheduler.get_run_result(test_args.request_id, algorithm).result_uri).text)
     run_meta = scheduler.get_request_metadata(test_args.request_id, algorithm)
     assert "number" in result and run_meta.payload_uri
+
+
+@pytest.mark.asyncio(loop_scope="package")
+async def test_failing_reader(scheduler: NexusSchedulerClient, cql_session: Session) -> None:
+    payload_url, request_id = negative_z_payload()
+    algorithm = os.getenv("NEXUS__ALGORITHM_NAME")
+    # create initial fake record
+    cql_session.execute(
+        f"INSERT INTO nexus.checkpoints (algorithm, id, lifecycle_stage, payload_uri, applied_configuration, configuration_overrides, parent) VALUES ('{algorithm}', '{request_id}', 'RUNNING', '{payload_url}', '{runtime_config_stub}', '{{}}', '{{}}')"
+    )
+    sys.argv = ["", "--sas-uri", payload_url, "--request-id", request_id]
+    await sample_algorithm_main()
+    await asyncio.sleep(1)
+    run_details = scheduler.get_request_metadata(request_id, algorithm)
+
+    assert (
+        run_details.lifecycle_stage == RequestLifeCycleStage.FAILED.value
+        and str(NegativeZError()) in run_details.algorithm_failure_details
+    )


### PR DESCRIPTION
## Scope

**Dependency updates:**

* Updated the Nexus service image in `docker-compose.yaml` from `1.1.5` to `1.1.7` and the Nexus Receiver image from `1.1.1` to `1.1.2` to ensure the latest features and bug fixes are used. [[1]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L42-R42) [[2]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L72-R72)

**Algorithm input validation and error handling:**

* Updated the main test suite to include a new test, `test_failing_reader`, which verifies that runs with negative `z` values are marked as failed and the error of type `NegativeZError` is recorded in the run metadata. [[1]](diffhunk://#diff-88d45d56ee2684ca0fc02f2a6c4f73b44ea97c8c5cf7b839fb286540b91340b3R45-R63) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R103-R112)

**SDK and typing improvements:**

* Fixed the decoding of the `lifecycle_stage` field in `scheduler.py` to ensure it is properly decoded from bytes if present.
* Implemented cache poisoning in case a run fails. [[1]](diffhunk://#diff-e016cbce5a01e9bccd02b7566c330990d3f1aac208bb31b77de95f35fe60dfcaL68-R68) [[2]](diffhunk://#diff-e016cbce5a01e9bccd02b7566c330990d3f1aac208bb31b77de95f35fe60dfcaR81-R85)

**Logging and telemetry:**

* Fixed incorrect logging of `else` branches for telemetry runs in `app_core.py`.