### PR TITLE
Add functionality to add multiple input object at once

### DIFF
--- a/nexus_client_sdk/nexus/core/app_core.py
+++ b/nexus_client_sdk/nexus/core/app_core.py
@@ -170,11 +170,29 @@ class Nexus:
         self._configurator = self._configurator.with_input_reader(reader)
         return self
 
+    def add_readers(self, *readers: type[InputReader]) -> "Nexus":
+        """
+        Adds an input data reader for the algorithm.
+        """
+        for reader in readers:
+            self._configurator = self._configurator.with_input_reader(reader)
+
+        return self
+
     def use_processor(self, input_processor: type[InputProcessor]) -> "Nexus":
         """
         Initialises an input processor for the algorithm.
         """
         self._configurator = self._configurator.with_input_processor(input_processor)
+        return self
+
+    def use_processors(self, *input_processors: type[InputProcessor]) -> "Nexus":
+        """
+        Initialises an input processor for the algorithm.
+        """
+        for input_processor in input_processors:
+            self._configurator = self._configurator.with_input_processor(input_processor)
+
         return self
 
     def use_algorithm(self, algorithm: type[BaselineAlgorithm]) -> "Nexus":

--- a/tests/sample_algorithm/sample_main.py
+++ b/tests/sample_algorithm/sample_main.py
@@ -240,10 +240,8 @@ async def main():
 
     nexus = (
         Nexus.create()
-        .add_reader(XYReader)
-        .add_reader(ZReader)
-        .use_processor(XYProcessor)
-        .use_processor(ZProcessor)
+        .add_readers(XYReader, ZReader)
+        .use_processors(XYProcessor, ZProcessor)
         .use_algorithm(TestAlgorithm)
         .on_complete(TestUserAnalyticsTelemetry)
         .inject_configuration(TestAlgorithmConfiguration)


### PR DESCRIPTION
Closes #71 

### What
* Added ```add_readers``` and ```use_processors``` method to Nexus core app

### Why
I think it follows how we define telemetry recorders, and I personally think it makes it more convenient to define the algorithm in the main methods. I prefer the more clean definition of the algorithm from the ```sample_main.py``` test. 