### PR TITLE
BUG-FIX: Dict can't be parsed to json in from_json method

### DIFF
--- a/nexus_client_sdk/nexus/input/payload_reader.py
+++ b/nexus_client_sdk/nexus/input/payload_reader.py
@@ -21,7 +21,6 @@ from dataclasses import dataclass
 
 from typing import final
 
-from adapta.storage.models.formatters import DictJsonSerializationFormat
 from adapta.utils import session_with_retries
 
 from dataclasses_json import DataClassJsonMixin
@@ -53,7 +52,7 @@ class AlgorithmPayloadReader:
             self._http = session_with_retries()
         http_response = self._http.get(url=self._payload_uri)
         http_response.raise_for_status()
-        self._payload = self._payload_type.from_json(DictJsonSerializationFormat().deserialize(http_response.content))
+        self._payload = self._payload_type.from_json(http_response.content)
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/nexus_client_sdk/nexus/input/payload_reader.py
+++ b/nexus_client_sdk/nexus/input/payload_reader.py
@@ -52,7 +52,7 @@ class AlgorithmPayloadReader:
             self._http = session_with_retries()
         http_response = self._http.get(url=self._payload_uri)
         http_response.raise_for_status()
-        self._payload = self._payload_type.from_json(http_response.content.decode("utf-8"))
+        self._payload = self._payload_type.from_json(http_response.content)
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/nexus_client_sdk/nexus/input/payload_reader.py
+++ b/nexus_client_sdk/nexus/input/payload_reader.py
@@ -52,7 +52,7 @@ class AlgorithmPayloadReader:
             self._http = session_with_retries()
         http_response = self._http.get(url=self._payload_uri)
         http_response.raise_for_status()
-        self._payload = self._payload_type.from_json(http_response.content)
+        self._payload = self._payload_type.from_json(http_response.content.decode("utf-8"))
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/nexus_client_sdk/testing/_functions.py
+++ b/nexus_client_sdk/testing/_functions.py
@@ -34,7 +34,7 @@ def generate_payload_url(
     :param storage_client:
     :return:
     """
-    data = payload_object.to_json()
+    data = DictJsonSerializationFormat().deserialize(payload_object.to_json().encode(encoding="utf-8"))
     obj_name = str(uuid.uuid4())
     upload_path = base_path.__class__.from_hdfs_path("/".join([base_path.to_hdfs_path(), obj_name]))
     storage_client.save_data_as_blob(

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,14 +2,14 @@
 
 [[package]]
 name = "adapta"
-version = "3.5.6"
+version = "3.5.7a553.dev2"
 description = "Logging, data connectors, monitoring, secret handling and general lifehacks to make data people lives easier."
 optional = false
 python-versions = "<3.13,>=3.11"
 groups = ["main"]
 files = [
-    {file = "adapta-3.5.6-py3-none-any.whl", hash = "sha256:a537011383ecf0109ab55f03b5af74de104cc3532b7d03014a31c287b357b8a8"},
-    {file = "adapta-3.5.6.tar.gz", hash = "sha256:a81addcdaae7e196729f83281ee9d7007dac3d3eac906dd21a2937c062c1216e"},
+    {file = "adapta-3.5.7a553.dev2-py3-none-any.whl", hash = "sha256:4115f216ebe000860721e5ab64d1af5a179ceab2097e09aeca072229ff28f52b"},
+    {file = "adapta-3.5.7a553.dev2.tar.gz", hash = "sha256:55064e72ceca6219c45d2a218ae49ef0c82d22403bb9086bb1612ce0b37a94c0"},
 ]
 
 [package.dependencies]
@@ -127,18 +127,18 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.40.44"
+version = "1.40.45"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "boto3-1.40.44-py3-none-any.whl", hash = "sha256:281ddf688951773a98161ccb34c54c6376b2ecc7028ab99d77483df5990b448c"},
-    {file = "boto3-1.40.44.tar.gz", hash = "sha256:84ade2a253e5445902d2cb2064f48aedf9ba83d6f863244266c2e36c2f190cec"},
+    {file = "boto3-1.40.45-py3-none-any.whl", hash = "sha256:5b145752d20f29908e3cb8c823bee31c77e6bcf18787e570f36bbc545cc779ed"},
+    {file = "boto3-1.40.45.tar.gz", hash = "sha256:e8d794dc1f01729d93dc188c90cf63cd0d32df8818a82ac46e641f6ffcea615e"},
 ]
 
 [package.dependencies]
-botocore = ">=1.40.44,<1.41.0"
+botocore = ">=1.40.45,<1.41.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.14.0,<0.15.0"
 
@@ -147,14 +147,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.40.44"
+version = "1.40.45"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "botocore-1.40.44-py3-none-any.whl", hash = "sha256:6fa7274cdb69be7c7b3ce6ff46a7c3e35e270f259dd77ee3f8ad8c584352262b"},
-    {file = "botocore-1.40.44.tar.gz", hash = "sha256:8f6f96ef053dcdfe79c14dfee303c0d381608c111696862fafc6e38402ccf8fe"},
+    {file = "botocore-1.40.45-py3-none-any.whl", hash = "sha256:9abf473d8372ade8442c0d4634a9decb89c854d7862ffd5500574eb63ab8f240"},
+    {file = "botocore-1.40.45.tar.gz", hash = "sha256:cf8b743527a2a7e108702d24d2f617e93c6dc7ae5eb09aadbe866f15481059df"},
 ]
 
 [package.dependencies]
@@ -281,14 +281,14 @@ graph = ["gremlinpython (==3.4.6)"]
 
 [[package]]
 name = "certifi"
-version = "2025.8.3"
+version = "2025.10.5"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5"},
-    {file = "certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407"},
+    {file = "certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de"},
+    {file = "certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43"},
 ]
 
 [[package]]
@@ -1591,14 +1591,14 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.9"
+version = "2.11.10"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic-2.11.9-py3-none-any.whl", hash = "sha256:c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2"},
-    {file = "pydantic-2.11.9.tar.gz", hash = "sha256:6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2"},
+    {file = "pydantic-2.11.10-py3-none-any.whl", hash = "sha256:802a655709d49bd004c31e865ef37da30b540786a46bfce02333e0e24b5fe29a"},
+    {file = "pydantic-2.11.10.tar.gz", hash = "sha256:dc280f0982fbda6c38fada4e476dc0a4f3aeaf9c6ad4c28df68a666ec3c61423"},
 ]
 
 [package.dependencies]
@@ -1740,14 +1740,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylint"
-version = "3.3.8"
+version = "3.3.9"
 description = "python code static checker"
 optional = false
 python-versions = ">=3.9.0"
 groups = ["dev"]
 files = [
-    {file = "pylint-3.3.8-py3-none-any.whl", hash = "sha256:7ef94aa692a600e82fabdd17102b73fc226758218c97473c7ad67bd4cb905d83"},
-    {file = "pylint-3.3.8.tar.gz", hash = "sha256:26698de19941363037e2937d3db9ed94fb3303fdadf7d98847875345a8bb6b05"},
+    {file = "pylint-3.3.9-py3-none-any.whl", hash = "sha256:01f9b0462c7730f94786c283f3e52a1fbdf0494bbe0971a78d7277ef46a751e7"},
+    {file = "pylint-3.3.9.tar.gz", hash = "sha256:d312737d7b25ccf6b01cc4ac629b5dcd14a0fcf3ec392735ac70f137a9d5f83a"},
 ]
 
 [package.dependencies]
@@ -1917,6 +1917,13 @@ optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
+    {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:efd7b85f94a6f21e4932043973a7ba2613b059c4a000551892ac9f1d11f5baf3"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22ba7cfcad58ef3ecddc7ed1db3409af68d023b7f940da23c6c2a1890976eda6"},
+    {file = "PyYAML-6.0.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:6344df0d5755a2c9a276d4473ae6b90647e216ab4757f8426893b5dd2ac3f369"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win32.whl", hash = "sha256:3ff07ec89bae51176c0549bc4c63aa6202991da2d9a6129d7aef7f1407d3f295"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:5cf4e27da7e3fbed4d6c3d8e797387aaad68102272f8f9752883bc32d61cb87b"},
     {file = "pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b"},
     {file = "pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956"},
     {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8"},
@@ -2338,4 +2345,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <3.13"
-content-hash = "2499f35c8ed32bedf20716218cb918f030ff71c55be33f72a22f1e88775c1e5d"
+content-hash = "e51bd4ac9ae66835b026003634acb7bbde9bdb1290058ae1a43eef8ac4630c87"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,14 +2,14 @@
 
 [[package]]
 name = "adapta"
-version = "3.5.7a553.dev2"
+version = "3.5.7"
 description = "Logging, data connectors, monitoring, secret handling and general lifehacks to make data people lives easier."
 optional = false
 python-versions = "<3.13,>=3.11"
 groups = ["main"]
 files = [
-    {file = "adapta-3.5.7a553.dev2-py3-none-any.whl", hash = "sha256:4115f216ebe000860721e5ab64d1af5a179ceab2097e09aeca072229ff28f52b"},
-    {file = "adapta-3.5.7a553.dev2.tar.gz", hash = "sha256:55064e72ceca6219c45d2a218ae49ef0c82d22403bb9086bb1612ce0b37a94c0"},
+    {file = "adapta-3.5.7-py3-none-any.whl", hash = "sha256:45f7dcae2b70b595da34d4707c91ca4ceb490a7b50dbebae8d88cfdc97cb542d"},
+    {file = "adapta-3.5.7.tar.gz", hash = "sha256:7686b52222d0738ecb5c666d645fac4681b5e0d14dd04f65f55f37984e1c59c5"},
 ]
 
 [package.dependencies]
@@ -127,18 +127,18 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.40.45"
+version = "1.40.46"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "boto3-1.40.45-py3-none-any.whl", hash = "sha256:5b145752d20f29908e3cb8c823bee31c77e6bcf18787e570f36bbc545cc779ed"},
-    {file = "boto3-1.40.45.tar.gz", hash = "sha256:e8d794dc1f01729d93dc188c90cf63cd0d32df8818a82ac46e641f6ffcea615e"},
+    {file = "boto3-1.40.46-py3-none-any.whl", hash = "sha256:0dfdc13992ceac1ef36a3ab0ac281cd4a45210a53181dc9a71afabfc1db889fe"},
+    {file = "boto3-1.40.46.tar.gz", hash = "sha256:3676767a03d84544b01b3390a2bbdc3b98479223661e90f0ba0b22f4d3f0cb9f"},
 ]
 
 [package.dependencies]
-botocore = ">=1.40.45,<1.41.0"
+botocore = ">=1.40.46,<1.41.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.14.0,<0.15.0"
 
@@ -147,14 +147,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.40.45"
+version = "1.40.46"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "botocore-1.40.45-py3-none-any.whl", hash = "sha256:9abf473d8372ade8442c0d4634a9decb89c854d7862ffd5500574eb63ab8f240"},
-    {file = "botocore-1.40.45.tar.gz", hash = "sha256:cf8b743527a2a7e108702d24d2f617e93c6dc7ae5eb09aadbe866f15481059df"},
+    {file = "botocore-1.40.46-py3-none-any.whl", hash = "sha256:d2c8e0d9ba804d6fd9b942db0aa3e6cfbdd9aab86581b472ee97809b6e5103e0"},
+    {file = "botocore-1.40.46.tar.gz", hash = "sha256:4b0c0efdba788117ef365bf930c0be7300fa052e5e195ea3ed53ab278fc6d7b1"},
 ]
 
 [package.dependencies]
@@ -2345,4 +2345,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <3.13"
-content-hash = "e51bd4ac9ae66835b026003634acb7bbde9bdb1290058ae1a43eef8ac4630c87"
+content-hash = "517579035e2df2eb22cbc6082f0b035433fc96046fc5e7219469899660d880f9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = ">=3.11, <3.13"
-adapta = { version = "^3.5.1", extras = ["aws", "storage", "datadog"] }
+adapta = { version = "v3.5.7a553.dev2", extras = ["aws", "storage", "datadog"] }
 injector = "^0.22.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = ">=3.11, <3.13"
-adapta = { version = "v3.5.7a553.dev2", extras = ["aws", "storage", "datadog"] }
+adapta = { version = "^3.5.7", extras = ["aws", "storage", "datadog"] }
 injector = "^0.22.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 import random
 import sys
 from dataclasses import dataclass
+from enum import Enum
 from logging import StreamHandler
 
 import pytest
@@ -29,11 +30,18 @@ class TestAlgorithmConfiguration(NexusConfiguration):
     c2: str
 
 
+class TestEnum(Enum):
+    A = "A"
+    B = "B"
+    C = "C"
+
+
 @dataclass
 class TestAlgorithmPayload(AlgorithmPayload, DataClassJsonMixin):
     x: list[int]
     y: list[int]
     z: list[int]
+    enum_value: TestEnum
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -95,7 +103,12 @@ def payloads() -> list[tuple[str, str]]:
     def _rand_range(limit: int) -> list[int]:
         return [random.randint(0, 10) for _ in range(limit)]
 
-    generated = [TestAlgorithmPayload(x=_rand_range(10), y=_rand_range(10), z=_rand_range(10)) for _ in range(10)]
+    generated = [
+        TestAlgorithmPayload(
+            x=_rand_range(10), y=_rand_range(10), z=_rand_range(10), enum_value=random.choice(list(TestEnum))
+        )
+        for _ in range(10)
+    ]
     return [
         generate_payload_url(upload_path, payload, S3StorageClient.for_storage_path(upload_path.to_hdfs_path()))
         for payload in generated
@@ -107,6 +120,6 @@ def negative_z_payload() -> tuple[str, str]:
 
     return generate_payload_url(
         upload_path,
-        TestAlgorithmPayload(x=[1, 2, 3], y=[4, 5, 6], z=[0, -1, 10]),
+        TestAlgorithmPayload(x=[1, 2, 3], y=[4, 5, 6], z=[0, -1, 10], enum_value=TestEnum.A),
         S3StorageClient.for_storage_path(upload_path.to_hdfs_path()),
     )


### PR DESCRIPTION
### What
* In https://github.com/SneaksAndData/nexus-sdk-py/pull/81, we introduced a bug, since from_json() can't parse dict objects. http_response.content is bytes already, which from_json handles. 
* Update generate_payload_url() method to make data into a dict, which is expected by the save_data_as_blob due to using DictJsonSerializationFormat as serializer. 
* Added enum to payload to make sure this e2e passes all the decoding/encoding