### PR TITLE
Improve parent referencing semantics for RemoteAlgorithm

### DIFF
--- a/nexus_client_sdk/nexus/algorithms/_remote_algorithm.py
+++ b/nexus_client_sdk/nexus/algorithms/_remote_algorithm.py
@@ -57,11 +57,25 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
         remote_client: NexusSchedulerAsyncClient,
         remote_name: str,
         *input_processors: InputProcessor,
+        is_hard_dependency: bool = False,
         remote_config: SdkCustomRunConfiguration | None = None,
         compressor: Compressor | None = None,
         compress_payload: bool = False,
         cache: InputCache,
     ):
+        """
+         Initialize a remote algorithm.
+        :param metrics_provider: MetricsProvider instance to use. Provided from DI, do not initialize manually.
+        :param logger_factory: LoggerFactory instance to use. Provided from DI, do not initialize manually.
+        :param remote_client: NexusSchedulerAsyncClient instance to use. Provided from DI, do not initialize manually.
+        :param remote_name: Name of the remote algorithm to use.
+        :param is_hard_dependency: If set to True, the launched run will set the initiator as Parent. Cancelling or completing the Parent will lead to remote run being aborted. If set to False, no Parent-Child relationship will be created. However, you can still override _generate_tag to retain the parent reference. Defaults to False.
+        :param input_processors: Inputs to use for payload generation
+        :param remote_config: Optional configuration for remote execution
+        :param compressor: Optional compressor to use for payload generation. Provided from DI, do not initialize manually.
+        :param compress_payload: If set to True, will compress the payload before creating a remote run.
+        :param cache: Input cache. Provided from DI, DO NOT initialize manually.
+        """
         super().__init__(metrics_provider, logger_factory)
         self._input_processors = input_processors
         self._remote_client = remote_client
@@ -70,9 +84,10 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
         self._cache = cache
         self._compressor = compressor
         self._compress_payload = compress_payload
+        self._is_hard_dependency = is_hard_dependency
 
     @abstractmethod
-    def _generate_tag(self) -> str:
+    def _generate_tag(self, **kwargs) -> str:
         """
         Generates a submission tag.
         """
@@ -126,7 +141,7 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
         )
         async def _measured_run(**run_args) -> AlgorithmResult:
             payloads = await self._run(**run_args)
-            tag = self._generate_tag()
+            tag = self._generate_tag(**run_args)
 
             request_ids = [
                 await self._remote_client.create_run(
@@ -137,7 +152,9 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
                     custom_configuration=self._remote_config,
                     parent_request=SdkParentRequest.create(
                         algorithm_name=os.getenv("NEXUS__ALGORITHM_NAME"), request_id=run_args["request_id"]
-                    ),
+                    )
+                    if self._is_hard_dependency
+                    else None,
                     tag=tag,
                     dry_run=os.getenv("NEXUS__REMOTE_DRY_RUN", "0") == "1",
                 )

--- a/tests/nexus/algorithms/test_remote_algorithm.py
+++ b/tests/nexus/algorithms/test_remote_algorithm.py
@@ -134,7 +134,7 @@ class TestRemoteAlgorithm(RemoteAlgorithm):
     def _context_open(self):
         pass
 
-    def _generate_tag(self) -> str:
+    def _generate_tag(self, **_) -> str:
         return "test-tag"
 
     async def _run(self, **kwargs):


### PR DESCRIPTION
### Dependency Management Improvements
* Added an `is_hard_dependency` parameter to the `RemoteAlgorithm` constructor, allowing control over whether a remote run is a hard dependency of its parent. If set to `True`, the parent-child relationship is enforced, and aborting the parent will also abort the remote run. 

### Extensibility and Documentation
* Updated the `_generate_tag` method to accept arbitrary keyword arguments (`**kwargs`), allowing more flexible tag generation based on runtime context. 
* Improved the constructor docstring to clearly describe all parameters and their intended usage, aiding future maintainers and users of the class.

*AI generated summary*