### PR TITLE
Fix startup error mapping on misconfigured storage client

### DIFF
--- a/nexus_client_sdk/nexus/core/app_dependencies.py
+++ b/nexus_client_sdk/nexus/core/app_dependencies.py
@@ -99,7 +99,12 @@ class StorageClientModule(Module):
         if "NEXUS__ALGORITHM_OUTPUT_PATH" not in os.environ:
             raise FatalStartupConfigurationError("NEXUS__ALGORITHM_OUTPUT_PATH")
 
-        return storage_client_class.for_storage_path(path=os.getenv("NEXUS__ALGORITHM_OUTPUT_PATH"))
+        try:
+            return storage_client_class.for_storage_path(path=os.getenv("NEXUS__ALGORITHM_OUTPUT_PATH"))
+        except Exception as e:
+            raise FatalStartupConfigurationError(
+                "StorageClient cannot be created, configuration missing or invalid. Review the underlying exception."
+            ) from e
 
 
 @final

--- a/nexus_client_sdk/nexus/exceptions/startup_error.py
+++ b/nexus_client_sdk/nexus/exceptions/startup_error.py
@@ -45,7 +45,7 @@ class FatalStartupConfigurationError(FatalNexusError):
         self._missing_entry = missing_entry
 
     def __str__(self) -> str:
-        return f"Algorithm initialization failed due to a missing configuration entry: {self._missing_entry}."
+        return f"Algorithm initialization failed due to a misconfigured dependency: {self._missing_entry}."
 
 
 class FatalAlgorithmConfigurationError(FatalNexusError):


### PR DESCRIPTION
Fixes https://github.com/SneaksAndData/nexus-sdk-py/issues/74

## Scope

Implemented:
 - Correctly throw `FatalStartupConfigurationError` if `StorageClient` initialization fails