### PR TITLE
BUG FIX: Logger missing keys for jitter

### DIFF
--- a/nexus_client_sdk/nexus/algorithms/forked_algorithm.py
+++ b/nexus_client_sdk/nexus/algorithms/forked_algorithm.py
@@ -149,7 +149,7 @@ class ForkedAlgorithm(NexusObject[TPayload, AlgorithmResult]):
             delay = int(os.getenv("NEXUS__FORK_SPAWN_BASE_DELAY_SECONDS", "0"))
             if delay > 0:
                 jitter = delay + random.random() * delay
-                self._logger.info(template="Spawning fork in {jitter:.2f}", jitter=jitter)
+                self._logger.info("Spawning fork in {jitter:.2f}", jitter=jitter)
                 await asyncio.sleep(delay + random.random() * delay)
 
             return asyncio.create_task(remote_algorithm.run(**remote_args))


### PR DESCRIPTION
Fixing bug introduced [here](https://github.com/SneaksAndData/nexus-sdk-py/pull/119/files#diff-bf656133a969a4b42efaf7a7904d0727e146502d1811f918a35b9dced202a343R152). See logs: 
```
Forking node with: simulatorpayloadbuilder, after the node run, (request_id:3ff22aad-9a3c-4d1c-9edd-01d82efb0ee8), (config_name:DK), (algorithm_name:supply-chain-simulation-orchestrator)

Algorithm supply-chain-simulation-orchestrator run failed on Nexus version 1.3.5, (request_id:3ff22aad-9a3c-4d1c-9edd-01d82efb0ee8), (config_name:DK), (algorithm_name:supply-chain-simulation-orchestrator)

Traceback (most recent call last):

  File "/app/supply_chain_simulation_orchestrator/.venv/lib/python3.11/site-packages/nexus_client_sdk/nexus/algorithms/forked_algorithm.py", line 180, in run

    [await _spawn(fork, **kwargs) for fork in forks], return_when=asyncio.ALL_COMPLETED

    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/app/supply_chain_simulation_orchestrator/.venv/lib/python3.11/site-packages/nexus_client_sdk/nexus/algorithms/forked_algorithm.py", line 180, in <listcomp>

    [await _spawn(fork, **kwargs) for fork in forks], return_when=asyncio.ALL_COMPLETED

     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/app/supply_chain_simulation_orchestrator/.venv/lib/python3.11/site-packages/nexus_client_sdk/nexus/algorithms/forked_algorithm.py", line 152, in _spawn

    self._logger.info("Spawning fork in {jitter:.2f}", jitter)

  File "/app/supply_chain_simulation_orchestrator/.venv/lib/python3.11/site-packages/adapta/logs/_async_logger.py", line 130, in info

    self._meta_info(template=template, logger=self._logger, tags=tags, **kwargs)

  File "/app/supply_chain_simulation_orchestrator/.venv/lib/python3.11/site-packages/adapta/logs/_internal_logger.py", line 127, in _meta_info

    msg = self._get_template(template).format(**log_args)

          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

KeyError: 'jitter'
```