### PR TITLE
Ensure piped commands fail on non Mac releases too

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,10 +79,11 @@ jobs:
         id: version
 
       - name: Install, Configure Poetry and Build
+        shell: bash
         env:
           VERSION: ${{steps.version.outputs.version}}
         run: |
-          set -e
+          set -euxo pipefail
 
           curl -sSL https://install.python-poetry.org | python3 -
           
@@ -133,10 +134,11 @@ jobs:
         id: version
 
       - name: Install, Configure Poetry and Build
+        shell: bash
         env:
           VERSION: ${{steps.version.outputs.version}}
         run: |
-          set -e
+          set -euxo pipefail
 
           curl -sSL https://install.python-poetry.org | python3 -
           


### PR DESCRIPTION
Fixes https://github.com/SneaksAndData/nexus-sdk-py/issues/122