### PR TITLE
Add get_request_metadata to Async Nexus Schedular Client

### DIFF
--- a/nexus_client_sdk/nexus/async_extensions/nexus_scheduler_async_client.py
+++ b/nexus_client_sdk/nexus/async_extensions/nexus_scheduler_async_client.py
@@ -29,6 +29,7 @@ from nexus_client_sdk.models.scheduler import (
     SdkParentRequest,
     RunResult,
     RequestLifeCycleStage,
+    RequestMetadata,
 )
 from nexus_client_sdk.nexus.async_extensions.async_exec import run_blocking
 from nexus_client_sdk.nexus.async_extensions.async_retry.async_retry_policy import (
@@ -197,4 +198,24 @@ class NexusSchedulerAsyncClient:
             ),
             "Fatal error when creating/awaiting a run",
             method_alias="create_and_await",
+        )
+
+    async def get_request_metadata(self, request_id: str, algorithm: str) -> RequestMetadata | None:
+        """
+        Gets metadata for a given run for a given algorithm.
+        :param request_id: Run request ID.
+        :param algorithm: Algorithm name.
+        :return:
+        """
+
+        return await self._retry_policy_builder.build().execute(
+            lambda: run_blocking(
+                partial(
+                    self._sync_client.get_request_metadata,
+                    request_id=request_id,
+                    algorithm=algorithm,
+                )
+            ),
+            f"Fatal error when getting metadata for request {algorithm}/{request_id}",
+            method_alias="get_request_metadata",
         )

--- a/tests/test_nexus_scheduler_async_client.py
+++ b/tests/test_nexus_scheduler_async_client.py
@@ -54,6 +54,14 @@ async def test_create_and_await(async_scheduler: NexusSchedulerAsyncClient):
     assert async_scheduler._sync_client.is_finished(result) and not async_scheduler._sync_client.has_succeeded(result)
 
 
+async def test_get_request_metadata(async_scheduler: NexusSchedulerAsyncClient):
+    result = await async_scheduler.create_and_await(algorithm_parameters={}, algorithm_name="hello-world")
+    meta_data = await async_scheduler.get_request_metadata(request_id=result.request_id, algorithm="hello-world")
+
+    assert meta_data.id == result.request_id
+    assert meta_data.algorithm == "hello-world"
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("propagate", [True, False])
 async def test_custom_error(propagate: bool, async_scheduler: NexusSchedulerAsyncClient, cql_session: Session):


### PR DESCRIPTION
## Scope

Implemented:
- ```get_request_metadata``` for the async nexus schedular client

## Checklist

- [ ] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [ ] Review requested on `latest` commit.
