### PR TITLE
Make sure Transient is not remapped to Fatal by _resolve_exc_type

### DIFF
--- a/nexus_client_sdk/nexus/abstractions/algorithm_cache.py
+++ b/nexus_client_sdk/nexus/abstractions/algorithm_cache.py
@@ -63,6 +63,12 @@ class InputCache:
         Resolve base exception into a specific Nexus exception.
         """
 
+        if isinstance(ex, FatalCachingError):
+            return FatalCachingError
+
+        if isinstance(ex, TransientCachingError):
+            return TransientCachingError
+
         match type(ex):
             case (
                 deltalake.exceptions.TableNotFoundError


### PR DESCRIPTION
Fixes https://github.com/SneaksAndData/nexus-sdk-py/issues/131