### PR TITLE
[Payload Serialization] Use Telemetry API to serialize payloads based on config provided

### DIFF
--- a/nexus_client_sdk/nexus/configurations/settings.toml
+++ b/nexus_client_sdk/nexus/configurations/settings.toml
@@ -20,8 +20,23 @@ additional_modules = [
     "nexus_client_sdk.nexus.core.app_dependencies.CompressorModule",
 ]
 
-# payload types supported by this Nexus application. At least one must be provided
-payload_types = []
+[payload]
+
+    # payload types supported by this Nexus application. At least one must be provided
+    types = []
+
+    # optional raw payload serialization for later analysis
+    # you can serialize payload via user telemetry, however that won't catch failed payloads
+    # for production scenarios recommended setup is to pair this setting with `on_failure` and
+    # a user telemetry recorder for successful runs
+    # Serialization is done via the same Telemetry API as regular user telemetry and uses a base path from telemetry settings
+    # Using `always` in production is also an option, unless you must maintain low running times
+    #
+    # Available values:
+    # off - do not serialize
+    # on_failure - serialize if none of the provided payload types match the payload
+    # always - always serialize the payload
+    serialization_mode = "off"
 
 # optional function that applies additional context to all logs emitted by Nexus.
 # accepts p: AlgorithmPayload and n: NexusDefaultArguments parameters

--- a/nexus_client_sdk/nexus/configurations/settings.toml
+++ b/nexus_client_sdk/nexus/configurations/settings.toml
@@ -20,24 +20,6 @@ additional_modules = [
     "nexus_client_sdk.nexus.core.app_dependencies.CompressorModule",
 ]
 
-[payload]
-
-    # payload types supported by this Nexus application. At least one must be provided
-    types = []
-
-    # optional raw payload serialization for later analysis
-    # you can serialize payload via user telemetry, however that won't catch failed payloads
-    # for production scenarios recommended setup is to pair this setting with `on_failure` and
-    # a user telemetry recorder for successful runs
-    # Serialization is done via the same Telemetry API as regular user telemetry and uses a base path from telemetry settings
-    # Using `always` in production is also an option, unless you must maintain low running times
-    #
-    # Available values:
-    # off - do not serialize
-    # on_failure - serialize if none of the provided payload types match the payload
-    # always - always serialize the payload
-    serialization_mode = "off"
-
 # optional function that applies additional context to all logs emitted by Nexus.
 # accepts p: AlgorithmPayload and n: NexusDefaultArguments parameters
 log_enrichment_function = ""
@@ -52,6 +34,24 @@ metric_tagging_function = ""
 
 # implementations of NexusConfiguration to be read from system environment
 configuration_types = []
+
+    [runtime.payload]
+
+        # payload types supported by this Nexus application. At least one must be provided
+        types = []
+
+        # optional raw payload serialization for later analysis
+        # you can serialize payload via user telemetry, however that won't catch failed payloads
+        # for production scenarios recommended setup is to pair this setting with `on_failure` and
+        # a user telemetry recorder for successful runs
+        # Serialization is done via the same Telemetry API as regular user telemetry and uses a base path from telemetry settings
+        # Using `always` in production is also an option, unless you must maintain low running times
+        #
+        # Available values:
+        # off - do not serialize
+        # on_failure - serialize if none of the provided payload types match the payload
+        # always - always serialize the payload
+        serialization_mode = "off"
 
 # Nexus client configuration
 [client]

--- a/nexus_client_sdk/nexus/core/app_bootstrap.py
+++ b/nexus_client_sdk/nexus/core/app_bootstrap.py
@@ -5,10 +5,12 @@ from typing import final, Callable
 
 from adapta.logs import LoggerInterface
 from adapta.metrics import MetricsProvider
+from adapta.metrics.providers.void_provider import VoidMetricsProvider
+from adapta.storage.blob.base import StorageClient
 from injector import Injector, Module, singleton
 
 from nexus_client_sdk.models.access_token import AccessToken
-from nexus_client_sdk.nexus.abstractions.logger_factory import BootstrapLoggerFactory, LoggerFactory
+from nexus_client_sdk.nexus.abstractions.logger_factory import BootstrapLoggerFactory, LoggerFactory, BootstrapLogger
 from nexus_client_sdk.nexus.abstractions.metrics_provider_factory import MetricsProviderFactory
 from nexus_client_sdk.nexus.algorithms import BaselineAlgorithm
 from nexus_client_sdk.nexus.async_extensions.nexus_receiver_async_client import NexusReceiverAsyncClient
@@ -25,13 +27,14 @@ from nexus_client_sdk.nexus.core.app_dependencies import (
     ResultSerializerModule,
     CacheModule,
 )
+from nexus_client_sdk.nexus.core.serializers import TelemetrySerializer
 from nexus_client_sdk.nexus.exceptions.startup_error import FatalStartupConfigurationError
 from nexus_client_sdk.nexus.input.command_line import NexusDefaultArguments
 from nexus_client_sdk.nexus.input.payload_reader import AlgorithmPayload, AlgorithmPayloadReader
 from nexus_client_sdk.nexus.telemetry.payload_recorder import (
-    PayloadRecorder,
+    PayloadTelemetry,
     FailedPayloadRecorder,
-    FailedPayloadResult,
+    PayloadResult,
 )
 from nexus_client_sdk.nexus.telemetry.recorder import TelemetryRecorder
 
@@ -53,7 +56,8 @@ class NexusBootstrapper:
     """
 
     def __init__(self, run_args: NexusDefaultArguments):
-        self._logger = BootstrapLoggerFactory().create_logger(
+        self._logger_factory = BootstrapLoggerFactory()
+        self._logger = self._logger_factory.create_logger(
             request_id=run_args.request_id,
             algorithm_name=NEXUS_FRAMEWORK_CONFIGURATION.default.algorithm_name,
         )
@@ -160,7 +164,7 @@ class NexusBootstrapper:
                 "No payload types specified - please supply at least one class in the [runtime.payload.types] array"
             )
 
-        for payload_type in NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload_types:
+        for payload_type in NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.types:
             payload_class: type[AlgorithmPayload] = locate(payload_type)
             if payload_class is None:
                 raise FatalStartupConfigurationError(f"Failed to locate required payload type: {payload_type}")
@@ -202,7 +206,8 @@ class NexusBootstrapper:
         for algorithm in NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.algorithms:
             self._load_algorithm(algorithm)
 
-    def _get_bootstrap_recorder(self) -> TelemetryRecorder | None:
+    def _get_bootstrap_recorder(self, logger_factory: LoggerFactory) -> TelemetryRecorder | None:
+        tmp_injector = Injector(self._injection_binds)
         if (
             NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.serialization_mode
             == _PayloadSerializationMode.OFF.value
@@ -212,7 +217,12 @@ class NexusBootstrapper:
             _PayloadSerializationMode.ON_FAILURE.value,
             _PayloadSerializationMode.ALWAYS.value,
         ]:
-            return Injector(self._injection_binds).get(TelemetryRecorder)
+            return TelemetryRecorder(
+                storage_client=tmp_injector.get(StorageClient),
+                serializer=tmp_injector.get(TelemetrySerializer),
+                metrics_provider=VoidMetricsProvider(),
+                logger_factory=logger_factory,
+            )
 
         return None
 
@@ -243,44 +253,23 @@ class NexusBootstrapper:
         for extension in self._startup_extensions:
             app_injector = extension(app_injector)
 
-        # get temporary telemetry recorder
-        bootstrap_recorder = self._get_bootstrap_recorder()
+        payload_read_results: dict[str, AlgorithmPayloadReader] = {}
 
         for payload_type in self._payload_types:
             payload, reader = await self._get_payload(
-                payload_type=payload_type, save_content=bootstrap_recorder is not None
+                payload_type=payload_type,
+                save_content=NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.serialization_mode
+                != _PayloadSerializationMode.OFF.value,
             )
             app_injector.binder.bind(payload.__class__, to=payload, scope=singleton)
             logger_fixed_template |= self._log_enricher(payload, self._run_args) if self._log_enricher else {}
             logger_tags |= self._log_tagger(payload, self._run_args) if self._log_tagger else {}
             metric_tags |= self._metric_tagger(payload, self._run_args) if self._metric_tagger else {}
+            payload_read_results |= {payload_type.__name__: reader}
 
-            if (
-                reader.read_exception is None
-                and NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.serialization_mode
-                == _PayloadSerializationMode.ALWAYS.value
-            ):
-                bootstrap_recorder.record_user_telemetry(
-                    user_recorder=app_injector.get(PayloadRecorder),
-                    run_id=self._run_args.request_id,
-                    result=None,
-                )
-            if (
-                reader.read_exception is not None
-                and NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.serialization_mode
-                == _PayloadSerializationMode.ON_FAILURE.value
-            ):
-                bootstrap_recorder.record_user_telemetry(
-                    user_recorder=app_injector.get(FailedPayloadRecorder),
-                    run_id=self._run_args.request_id,
-                    result=FailedPayloadResult(reader.payload_str),
-                )
-                raise FatalStartupConfigurationError(
-                    f"Unable to parse payload from {self._run_args.sas_uri} into {str(payload_type)}"
-                ) from reader.read_exception
-
-            for resolver in self._algorithm_resolvers:
-                self._load_algorithm(resolver(payload))
+            if payload is not None:
+                for resolver in self._algorithm_resolvers:
+                    self._load_algorithm(resolver(payload))
 
         logger_factory = LoggerFactory(
             fixed_template=logger_fixed_template,
@@ -304,6 +293,35 @@ class NexusBootstrapper:
             to=metrics_provider,
             scope=singleton,
         )
+
+        # get temporary telemetry recorder
+        bootstrap_recorder = self._get_bootstrap_recorder(logger_factory)
+
+        if bootstrap_recorder is not None:
+            for payload_type, payload_reader in payload_read_results.items():
+                if (
+                    payload_reader.read_exception is None
+                    and NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.serialization_mode
+                    == _PayloadSerializationMode.ALWAYS.value
+                ):
+                    bootstrap_recorder.record_user_telemetry(
+                        user_recorder=app_injector.get(PayloadTelemetry),
+                        run_id=self._run_args.request_id,
+                        result=PayloadResult(payload_reader.payload_str),
+                    )
+                if (
+                    payload_reader.read_exception is not None
+                    and NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.serialization_mode
+                    == _PayloadSerializationMode.ON_FAILURE.value
+                ):
+                    bootstrap_recorder.record_user_telemetry(
+                        user_recorder=app_injector.get(FailedPayloadRecorder),
+                        run_id=self._run_args.request_id,
+                        result=PayloadResult(payload_reader.payload_str),
+                    )
+                    raise FatalStartupConfigurationError(
+                        f"Unable to parse payload from {self._run_args.sas_uri} into {str(payload_type)}"
+                    ) from payload_reader.read_exception
 
         # create and bind receiver client
         receiver_client = NexusReceiverAsyncClient(

--- a/nexus_client_sdk/nexus/core/app_bootstrap.py
+++ b/nexus_client_sdk/nexus/core/app_bootstrap.py
@@ -10,7 +10,7 @@ from adapta.storage.blob.base import StorageClient
 from injector import Injector, Module, singleton
 
 from nexus_client_sdk.models.access_token import AccessToken
-from nexus_client_sdk.nexus.abstractions.logger_factory import BootstrapLoggerFactory, LoggerFactory, BootstrapLogger
+from nexus_client_sdk.nexus.abstractions.logger_factory import BootstrapLoggerFactory, LoggerFactory
 from nexus_client_sdk.nexus.abstractions.metrics_provider_factory import MetricsProviderFactory
 from nexus_client_sdk.nexus.algorithms import BaselineAlgorithm
 from nexus_client_sdk.nexus.async_extensions.nexus_receiver_async_client import NexusReceiverAsyncClient
@@ -297,31 +297,33 @@ class NexusBootstrapper:
         # get temporary telemetry recorder
         bootstrap_recorder = self._get_bootstrap_recorder(logger_factory)
 
-        if bootstrap_recorder is not None:
-            for payload_type, payload_reader in payload_read_results.items():
-                if (
-                    payload_reader.read_exception is None
-                    and NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.serialization_mode
-                    == _PayloadSerializationMode.ALWAYS.value
-                ):
-                    bootstrap_recorder.record_user_telemetry(
-                        user_recorder=app_injector.get(PayloadTelemetry),
-                        run_id=self._run_args.request_id,
-                        result=PayloadResult(payload_reader.payload_str),
-                    )
-                if (
-                    payload_reader.read_exception is not None
-                    and NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.serialization_mode
-                    == _PayloadSerializationMode.ON_FAILURE.value
-                ):
-                    bootstrap_recorder.record_user_telemetry(
-                        user_recorder=app_injector.get(FailedPayloadRecorder),
-                        run_id=self._run_args.request_id,
-                        result=PayloadResult(payload_reader.payload_str),
-                    )
-                    raise FatalStartupConfigurationError(
-                        f"Unable to parse payload from {self._run_args.sas_uri} into {str(payload_type)}"
-                    ) from payload_reader.read_exception
+        for payload_type, payload_reader in payload_read_results.items():
+            if (
+                payload_reader.read_exception is None
+                and NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.serialization_mode
+                == _PayloadSerializationMode.ALWAYS.value
+            ):
+                bootstrap_recorder.record_user_telemetry(
+                    user_recorder=app_injector.get(PayloadTelemetry),
+                    run_id=self._run_args.request_id,
+                    result=PayloadResult(payload_reader.payload_str),
+                )
+            if (
+                payload_reader.read_exception is not None
+                and NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.serialization_mode
+                == _PayloadSerializationMode.ON_FAILURE.value
+            ):
+                bootstrap_recorder.record_user_telemetry(
+                    user_recorder=app_injector.get(FailedPayloadRecorder),
+                    run_id=self._run_args.request_id,
+                    result=PayloadResult(payload_reader.payload_str),
+                )
+
+            # always report payload parsing failures
+            if payload_reader.read_exception is not None:
+                raise FatalStartupConfigurationError(
+                    f"Unable to parse payload from {self._run_args.sas_uri} into {str(payload_type)}"
+                ) from payload_reader.read_exception
 
         # create and bind receiver client
         receiver_client = NexusReceiverAsyncClient(

--- a/nexus_client_sdk/nexus/core/app_bootstrap.py
+++ b/nexus_client_sdk/nexus/core/app_bootstrap.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import Enum
 from pydoc import locate
 from typing import final, Callable
 
@@ -27,7 +28,22 @@ from nexus_client_sdk.nexus.core.app_dependencies import (
 from nexus_client_sdk.nexus.exceptions.startup_error import FatalStartupConfigurationError
 from nexus_client_sdk.nexus.input.command_line import NexusDefaultArguments
 from nexus_client_sdk.nexus.input.payload_reader import AlgorithmPayload, AlgorithmPayloadReader
+from nexus_client_sdk.nexus.telemetry.payload_recorder import (
+    PayloadRecorder,
+    FailedPayloadRecorder,
+    FailedPayloadResult,
+)
 from nexus_client_sdk.nexus.telemetry.recorder import TelemetryRecorder
+
+
+class _PayloadSerializationMode(Enum):
+    """
+    Serialization modes for [runtime.payload.serialization_mode]. Bootstrap-only access.
+    """
+
+    OFF = "off"
+    ON_FAILURE = "on_failure"
+    ALWAYS = "always"
 
 
 @final
@@ -54,7 +70,10 @@ class NexusBootstrapper:
             config_validation_extension,
             app_configuration_loader_extension,
         ]
+        # payload processing
         self._payload_types: list[type[AlgorithmPayload]] = []
+
+        # observability
         self._log_enricher: Callable[
             [
                 AlgorithmPayload,
@@ -77,15 +96,21 @@ class NexusBootstrapper:
             ],
             dict[str, str],
         ] | None = None
+
+        # algorithm loading
         self._algorithm_classes: set[type[BaselineAlgorithm]] = set()
         self._algorithm_resolvers: list[Callable[[AlgorithmPayload], str]] = []
 
-    async def _get_payload(self, payload_type: type[AlgorithmPayload]) -> AlgorithmPayload:
-        async with AlgorithmPayloadReader(
+    async def _get_payload(
+        self, payload_type: type[AlgorithmPayload], save_content: bool
+    ) -> tuple[AlgorithmPayload | None, AlgorithmPayloadReader]:
+        reader = AlgorithmPayloadReader(
             payload_uri=self._run_args.sas_uri,
             payload_type=payload_type,
-        ) as reader:
-            return reader.payload
+            save_content=save_content,
+        )
+        async with reader:
+            return reader.payload, reader
 
     @property
     def algorithm_classes(self) -> set[type[BaselineAlgorithm]]:
@@ -130,9 +155,9 @@ class NexusBootstrapper:
                 ) from error
 
     def _load_payload_types(self):
-        if not NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload_types:
+        if not NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.types:
             raise FatalStartupConfigurationError(
-                "No payload types specified - please supply at least one class in the [runtime.payload_types] array"
+                "No payload types specified - please supply at least one class in the [runtime.payload.types] array"
             )
 
         for payload_type in NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload_types:
@@ -177,6 +202,20 @@ class NexusBootstrapper:
         for algorithm in NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.algorithms:
             self._load_algorithm(algorithm)
 
+    def _get_bootstrap_recorder(self) -> TelemetryRecorder | None:
+        if (
+            NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.serialization_mode
+            == _PayloadSerializationMode.OFF.value
+        ):
+            return None
+        if NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.serialization_mode in [
+            _PayloadSerializationMode.ON_FAILURE.value,
+            _PayloadSerializationMode.ALWAYS.value,
+        ]:
+            return Injector(self._injection_binds).get(TelemetryRecorder)
+
+        return None
+
     async def __aenter__(self):
         self._logger.start()
 
@@ -204,12 +243,41 @@ class NexusBootstrapper:
         for extension in self._startup_extensions:
             app_injector = extension(app_injector)
 
+        # get temporary telemetry recorder
+        bootstrap_recorder = self._get_bootstrap_recorder()
+
         for payload_type in self._payload_types:
-            payload = await self._get_payload(payload_type=payload_type)
+            payload, reader = await self._get_payload(
+                payload_type=payload_type, save_content=bootstrap_recorder is not None
+            )
             app_injector.binder.bind(payload.__class__, to=payload, scope=singleton)
             logger_fixed_template |= self._log_enricher(payload, self._run_args) if self._log_enricher else {}
             logger_tags |= self._log_tagger(payload, self._run_args) if self._log_tagger else {}
             metric_tags |= self._metric_tagger(payload, self._run_args) if self._metric_tagger else {}
+
+            if (
+                reader.read_exception is None
+                and NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.serialization_mode
+                == _PayloadSerializationMode.ALWAYS.value
+            ):
+                bootstrap_recorder.record_user_telemetry(
+                    user_recorder=app_injector.get(PayloadRecorder),
+                    run_id=self._run_args.request_id,
+                    result=None,
+                )
+            if (
+                reader.read_exception is not None
+                and NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.payload.serialization_mode
+                == _PayloadSerializationMode.ON_FAILURE.value
+            ):
+                bootstrap_recorder.record_user_telemetry(
+                    user_recorder=app_injector.get(FailedPayloadRecorder),
+                    run_id=self._run_args.request_id,
+                    result=FailedPayloadResult(reader.payload_str),
+                )
+                raise FatalStartupConfigurationError(
+                    f"Unable to parse payload from {self._run_args.sas_uri} into {str(payload_type)}"
+                ) from reader.read_exception
 
             for resolver in self._algorithm_resolvers:
                 self._load_algorithm(resolver(payload))

--- a/nexus_client_sdk/nexus/input/payload_reader.py
+++ b/nexus_client_sdk/nexus/input/payload_reader.py
@@ -84,18 +84,22 @@ class AlgorithmPayloadReader:
             self._http = session_with_retries()
         http_response = await run_blocking(partial(self._http.get, url=self._payload_uri))
         http_response.raise_for_status()
+        content = http_response.content
 
         compressed_payload: CompressedPayload | None = None
 
         try:
-            compressed_payload = CompressedPayload.from_json(http_response.content)
-        except Exception:  # pylint: disable=broad-except
+            compressed_payload = CompressedPayload.from_json(content)
+        except BaseException:  # pylint: disable=broad-except
             pass
 
         if compressed_payload is not None:
-            self._payload = self._payload_type.from_json(compressed_payload.decompress())
+            self._try_parse(compressed_payload.decompress())
         else:
-            self._payload = self._payload_type.from_json(http_response.content)
+            self._try_parse(content)
+
+        if self._save_content:
+            self._payload_str = content
 
         return self
 
@@ -103,16 +107,25 @@ class AlgorithmPayloadReader:
         self._http.close()
         self._http = None
 
-    def __init__(self, payload_uri: str, payload_type: type[AlgorithmPayload]):
+    def _try_parse(self, payload_data: str | bytes | bytearray):
+        try:
+            self._payload = self._payload_type.from_json(payload_data)
+        except BaseException as error:  # pylint: disable=broad-except
+            self._read_exc = error
+
+    def __init__(self, payload_uri: str, payload_type: type[AlgorithmPayload], save_content: bool):
         self._http = session_with_retries()
+        self._save_content = save_content
         self._payload: AlgorithmPayload | None = None
+        self._payload_str: str | None = None
         self._payload_uri = payload_uri
         self._payload_type = payload_type
+        self._read_exc: BaseException | None = None
 
     @property
     def payload_uri(self) -> str:
         """
-        Uri of the paylod for the algorithm
+        Uri of the payload for the algorithm.
         """
         return self._payload_uri
 
@@ -122,3 +135,18 @@ class AlgorithmPayloadReader:
         Payload data deserialized into the user class.
         """
         return self._payload
+
+    @property
+    def payload_str(self) -> str | None:
+        """
+        Raw payload bytes.
+        """
+        return self._payload_str
+
+    @property
+    def read_exception(self) -> BaseException | None:
+        """
+         Read exception, if any
+        :return:
+        """
+        return self._read_exc

--- a/nexus_client_sdk/nexus/input/payload_reader.py
+++ b/nexus_client_sdk/nexus/input/payload_reader.py
@@ -84,7 +84,7 @@ class AlgorithmPayloadReader:
             self._http = session_with_retries()
         http_response = await run_blocking(partial(self._http.get, url=self._payload_uri))
         http_response.raise_for_status()
-        content = http_response.content
+        content: bytes = http_response.content
 
         compressed_payload: CompressedPayload | None = None
 
@@ -99,7 +99,7 @@ class AlgorithmPayloadReader:
             self._try_parse(content)
 
         if self._save_content:
-            self._payload_str = content
+            self._payload_str = content.decode("utf-8")
 
         return self
 

--- a/nexus_client_sdk/nexus/telemetry/payload_recorder.py
+++ b/nexus_client_sdk/nexus/telemetry/payload_recorder.py
@@ -3,30 +3,45 @@ from typing import final, Any
 
 import pandas
 import polars
+from adapta.metrics import MetricsProvider
+from adapta.storage.blob.base import StorageClient
+from injector import inject
 
 from pandas import DataFrame
 
-
+from nexus_client_sdk.nexus.abstractions.logger_factory import LoggerFactory
 from nexus_client_sdk.nexus.abstractions.nexus_object import AlgorithmResult, TPayload, TResult
+from nexus_client_sdk.nexus.core.serializers import TelemetrySerializer
 from nexus_client_sdk.nexus.input.payload_reader import AlgorithmPayload
 from nexus_client_sdk.nexus.telemetry.user_telemetry_recorder import UserTelemetryRecorder, UserTelemetry
 
 
 @final
-class PayloadRecorder(UserTelemetryRecorder[AlgorithmPayload, AlgorithmResult]):
+class PayloadTelemetry(UserTelemetryRecorder[str, AlgorithmResult]):
     """
     Native recorder for algorithm payloads that were successfully parsed
     """
 
+    @inject
+    def __init__(
+        self,
+        algorithm_payload: str,
+        metrics_provider: MetricsProvider,
+        logger_factory: LoggerFactory,
+        storage_client: StorageClient,
+        serializer: TelemetrySerializer,
+    ):
+        super().__init__(algorithm_payload, metrics_provider, logger_factory, storage_client, serializer)
+
     async def _compute(
-        self, algorithm_payload: AlgorithmPayload, algorithm_result: AlgorithmResult, run_id: str, **inputs: DataFrame
+        self, algorithm_payload: str, algorithm_result: AlgorithmResult, run_id: str, **inputs: DataFrame
     ) -> UserTelemetry:
         return UserTelemetry(
             iter(
                 [
                     DataFrame(
                         {
-                            "payload": algorithm_payload.to_json(orient="records"),
+                            "payload": algorithm_result.result()["data"],
                             "request_id": run_id,
                             "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                             "is_valid": True,
@@ -42,6 +57,17 @@ class FailedPayloadRecorder(UserTelemetryRecorder[str, AlgorithmResult]):
     """
     Native recorder for algorithm payloads that failed to parse into provided type
     """
+
+    @inject
+    def __init__(
+        self,
+        algorithm_payload: str,
+        metrics_provider: MetricsProvider,
+        logger_factory: LoggerFactory,
+        storage_client: StorageClient,
+        serializer: TelemetrySerializer,
+    ):
+        super().__init__(algorithm_payload, metrics_provider, logger_factory, storage_client, serializer)
 
     async def _compute(
         self, algorithm_payload: str, algorithm_result: AlgorithmResult, run_id: str, **inputs: DataFrame
@@ -63,7 +89,7 @@ class FailedPayloadRecorder(UserTelemetryRecorder[str, AlgorithmResult]):
 
 
 @final
-class FailedPayloadResult(AlgorithmResult):
+class PayloadResult(AlgorithmResult):
     """
     Result for the failed payload to be used with telemetry recorder.
     """

--- a/nexus_client_sdk/nexus/telemetry/payload_recorder.py
+++ b/nexus_client_sdk/nexus/telemetry/payload_recorder.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timezone
+from typing import final, Any
+
+import pandas
+import polars
+
+from pandas import DataFrame
+
+
+from nexus_client_sdk.nexus.abstractions.nexus_object import AlgorithmResult, TPayload, TResult
+from nexus_client_sdk.nexus.input.payload_reader import AlgorithmPayload
+from nexus_client_sdk.nexus.telemetry.user_telemetry_recorder import UserTelemetryRecorder, UserTelemetry
+
+
+@final
+class PayloadRecorder(UserTelemetryRecorder[AlgorithmPayload, AlgorithmResult]):
+    """
+    Native recorder for algorithm payloads that were successfully parsed
+    """
+
+    async def _compute(
+        self, algorithm_payload: AlgorithmPayload, algorithm_result: AlgorithmResult, run_id: str, **inputs: DataFrame
+    ) -> UserTelemetry:
+        return UserTelemetry(
+            iter(
+                [
+                    DataFrame(
+                        {
+                            "payload": algorithm_payload.to_json(orient="records"),
+                            "request_id": run_id,
+                            "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                            "is_valid": True,
+                        }
+                    )
+                ]
+            ),
+        )
+
+
+@final
+class FailedPayloadRecorder(UserTelemetryRecorder[str, AlgorithmResult]):
+    """
+    Native recorder for algorithm payloads that failed to parse into provided type
+    """
+
+    async def _compute(
+        self, algorithm_payload: str, algorithm_result: AlgorithmResult, run_id: str, **inputs: DataFrame
+    ) -> UserTelemetry:
+        return UserTelemetry(
+            iter(
+                [
+                    DataFrame(
+                        {
+                            "payload": algorithm_result.result()["data"],
+                            "request_id": run_id,
+                            "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                            "is_valid": False,
+                        }
+                    )
+                ]
+            )
+        )
+
+
+@final
+class FailedPayloadResult(AlgorithmResult):
+    """
+    Result for the failed payload to be used with telemetry recorder.
+    """
+
+    def __init__(self, content: str):
+        self._content = content
+
+    def result(self) -> pandas.DataFrame | polars.DataFrame | dict:
+        return {
+            "content": self._content,
+        }
+
+    def to_kwargs(self) -> dict[str, Any]:
+        pass

--- a/nexus_client_sdk/nexus/telemetry/payload_recorder.py
+++ b/nexus_client_sdk/nexus/telemetry/payload_recorder.py
@@ -6,13 +6,11 @@ import polars
 from adapta.metrics import MetricsProvider
 from adapta.storage.blob.base import StorageClient
 from injector import inject
-
 from pandas import DataFrame
 
 from nexus_client_sdk.nexus.abstractions.logger_factory import LoggerFactory
-from nexus_client_sdk.nexus.abstractions.nexus_object import AlgorithmResult, TPayload, TResult
+from nexus_client_sdk.nexus.abstractions.nexus_object import AlgorithmResult
 from nexus_client_sdk.nexus.core.serializers import TelemetrySerializer
-from nexus_client_sdk.nexus.input.payload_reader import AlgorithmPayload
 from nexus_client_sdk.nexus.telemetry.user_telemetry_recorder import UserTelemetryRecorder, UserTelemetry
 
 

--- a/tests/nexus/input/test_payload_reader.py
+++ b/tests/nexus/input/test_payload_reader.py
@@ -133,7 +133,7 @@ async def test__algorithm_payload_reader__general(
     mock_session_factory.return_value = mock_session
 
     dummy_uri = "http://mock.uri/payload.json"
-    reader = AlgorithmPayloadReader(payload_uri=dummy_uri, payload_type=SimpleTestPayload, save_content=False)
+    reader = AlgorithmPayloadReader(payload_uri=dummy_uri, payload_type=SimpleTestPayload, save_content=True)
 
     # Act
     async with reader as payload_reader:
@@ -142,6 +142,7 @@ async def test__algorithm_payload_reader__general(
     # Assert
     assert result_payload is not None
     assert result_payload == expected.expected_payload
+    assert inputs.payload_content_bytes.decode("utf-8") == reader.payload_str
 
     # Verify that the mock HTTP client was called as expected
     mock_session.get.assert_called_once_with(url=dummy_uri)

--- a/tests/nexus/input/test_payload_reader.py
+++ b/tests/nexus/input/test_payload_reader.py
@@ -133,7 +133,7 @@ async def test__algorithm_payload_reader__general(
     mock_session_factory.return_value = mock_session
 
     dummy_uri = "http://mock.uri/payload.json"
-    reader = AlgorithmPayloadReader(payload_uri=dummy_uri, payload_type=SimpleTestPayload)
+    reader = AlgorithmPayloadReader(payload_uri=dummy_uri, payload_type=SimpleTestPayload, save_content=False)
 
     # Act
     async with reader as payload_reader:

--- a/tests/settings.custom.toml
+++ b/tests/settings.custom.toml
@@ -16,8 +16,23 @@ additional_modules = [
     "nexus_client_sdk.nexus.core.app_dependencies.CompressorModule",
 ]
 
-# payload types supported by this Nexus application. At least one must be provided
-payload_types = ["tests.conftest.TestAlgorithmPayload"]
+[payload]
+
+    # payload types supported by this Nexus application. At least one must be provided
+    types = ["tests.conftest.TestAlgorithmPayload"]
+
+    # optional raw payload serialization for later analysis
+    # you can serialize payload via user telemetry, however that won't catch failed payloads
+    # for production scenarios recommended setup is to pair this setting with `on_failure` and
+    # a user telemetry recorder for successful runs
+    # Serialization is done via the same Telemetry API as regular user telemetry and uses a base path from telemetry settings
+    # Using `always` in production is also an option, unless you must maintain low running times
+    #
+    # Available values:
+    # off - do not serialize
+    # on_failure - serialize if none of the provided payload types match the payload
+    # always - always serialize the payload
+    serialization_mode = "always"
 
 # optional function that applies additional context to all logs emitted by Nexus.
 # accepts p: AlgorithmPayload and n: NexusDefaultArguments parameters

--- a/tests/settings.custom.toml
+++ b/tests/settings.custom.toml
@@ -16,7 +16,23 @@ additional_modules = [
     "nexus_client_sdk.nexus.core.app_dependencies.CompressorModule",
 ]
 
-[payload]
+# optional function that applies additional context to all logs emitted by Nexus.
+# accepts p: AlgorithmPayload and n: NexusDefaultArguments parameters
+log_enrichment_function = "tests.sample_algorithm.sample_main.enrich_from_payload"
+
+# optional function that applies additional tags (as metadata) to all logs emitted by Nexus.
+# accepts p: AlgorithmPayload and n: NexusDefaultArguments parameters
+log_tagging_function = "tests.sample_algorithm.sample_main.tags_from_payload"
+
+# optional function that applies additional tagging to all metrics emitted by Nexus.
+# accepts p: AlgorithmPayload and n: NexusDefaultArguments parameters
+metric_tagging_function = "tests.sample_algorithm.sample_main.tag_metrics"
+
+configuration_types = [
+    "tests.conftest.TestAlgorithmConfiguration"
+]
+
+[runtime.payload]
 
     # payload types supported by this Nexus application. At least one must be provided
     types = ["tests.conftest.TestAlgorithmPayload"]
@@ -33,22 +49,6 @@ additional_modules = [
     # on_failure - serialize if none of the provided payload types match the payload
     # always - always serialize the payload
     serialization_mode = "always"
-
-# optional function that applies additional context to all logs emitted by Nexus.
-# accepts p: AlgorithmPayload and n: NexusDefaultArguments parameters
-log_enrichment_function = "tests.sample_algorithm.sample_main.enrich_from_payload"
-
-# optional function that applies additional tags (as metadata) to all logs emitted by Nexus.
-# accepts p: AlgorithmPayload and n: NexusDefaultArguments parameters
-log_tagging_function = "tests.sample_algorithm.sample_main.tags_from_payload"
-
-# optional function that applies additional tagging to all metrics emitted by Nexus.
-# accepts p: AlgorithmPayload and n: NexusDefaultArguments parameters
-metric_tagging_function = "tests.sample_algorithm.sample_main.tag_metrics"
-
-configuration_types = [
-    "tests.conftest.TestAlgorithmConfiguration"
-]
 
 # Result processing and serialization
 [result]


### PR DESCRIPTION
Closes https://github.com/SneaksAndData/nexus-sdk-py/issues/99

Support payload serialization via Telemetry API, allowing for configurable recording of both correct and failed payloads during application bootstrap.

**Key changes:**

### Configuration changes

* Refactored payload type configuration from `payload_types = []` to a new `[runtime.payload]` TOML section with `types = []` and a new `serialization_mode` option (`off`, `on_failure`, `always`) in both `settings.toml` and `tests/settings.custom.toml`. 

### Payload reading and serialization logic

* Updated `AlgorithmPayloadReader` to support saving the raw payload content and capturing any exceptions during payload parsing. Added properties for `payload_str` (raw content) and `read_exception`
* Modified `NexusBootstrapper` to use the new payload serialization mode, passing the `save_content` flag to the reader, collecting payloads and their readers, and handling serialization logic based on the configured mode. 

### Telemetry and recording support

* Added new telemetry recorder classes: `PayloadTelemetry` for successful payloads, `FailedPayloadRecorder` for failed payloads, and `PayloadResult` as a wrapper for payload content. These recorders use the Telemetry API to store payloads for later analysis, with metadata such as request ID and validity.
* Integrated the new recorders into the bootstrap process, so payloads are recorded according to the selected serialization mode, and failed payloads raise a startup error after recording. Default mode is no recording (off), to have the current behaviour preserved.

**AI summary - edited**