### PR TITLE
Introduce exception re-mapping API

### DIFF
--- a/nexus_client_sdk/nexus/abstractions/algorithm_cache.py
+++ b/nexus_client_sdk/nexus/abstractions/algorithm_cache.py
@@ -21,15 +21,13 @@ import asyncio
 from functools import reduce
 from typing import final, Any
 
-import deltalake.exceptions
-import cassandra
-
 from nexus_client_sdk.nexus.abstractions.input_object import InputObject
 from nexus_client_sdk.nexus.abstractions.nexus_object import TResult, TPayload
 from nexus_client_sdk.nexus.exceptions.cache_errors import (
     FatalCachingError,
     TransientCachingError,
 )
+from nexus_client_sdk.nexus.exceptions.error_map import NexusErrorMapCollection
 
 
 @final
@@ -38,11 +36,12 @@ class InputCache:
     In-memory cache for Nexus input readers/processors
     """
 
-    def __init__(self):
+    def __init__(self, error_map_collection: NexusErrorMapCollection) -> None:
         self._cache: dict[str, Any] = {}
         self._scheduled: dict[str, asyncio.Task] = {}
         self._total_executed: int = 0
         self._lock = asyncio.Lock()
+        self._error_map_collection = error_map_collection
 
     def total_evaluated_inputs(self) -> int:
         """
@@ -69,30 +68,7 @@ class InputCache:
         if isinstance(ex, TransientCachingError):
             return TransientCachingError
 
-        match type(ex):
-            case (
-                deltalake.exceptions.TableNotFoundError
-                | deltalake.exceptions.DeltaProtocolError
-                | deltalake.exceptions.CommitFailedError
-                | deltalake.exceptions.DeltaProtocolError
-                | deltalake.exceptions.SchemaMismatchError
-            ):
-                return TransientCachingError
-            case cassandra.Unauthorized | cassandra.RequestValidationException | cassandra.AuthenticationFailed:
-                return TransientCachingError
-            case (
-                cassandra.Timeout
-                | cassandra.Unavailable
-                | cassandra.ReadTimeout
-                | cassandra.WriteTimeout
-                | cassandra.OperationTimedOut
-                | cassandra.ReadFailure
-                | cassandra.ReadFailure
-                | cassandra.CoordinationFailure
-            ):
-                return TransientCachingError
-            case _:
-                return FatalCachingError
+        return self._error_map_collection.map_error(ex, self.__class__)
 
     async def resolve(
         self,

--- a/nexus_client_sdk/nexus/configurations/runtime_configuration.py
+++ b/nexus_client_sdk/nexus/configurations/runtime_configuration.py
@@ -1,4 +1,5 @@
 """Framework configuration"""
+from pydoc import locate
 from typing import final
 
 from adapta.logs.models import LogLevel
@@ -13,6 +14,15 @@ def _try_parse_log_level(log_level: str) -> bool:
         return True
     except ValueError:
         return False
+
+
+def _try_locate_error_classes(error_classes: list[dict]) -> bool:
+    for error_class_def in error_classes:
+        for error_class in error_class_def["errors"]:
+            if locate(error_class) is None:
+                return False
+
+    return True
 
 
 @final
@@ -71,6 +81,46 @@ class NexusRuntimeConfiguration:
                 apply_default_on_none=True,
                 default="INFO",
                 condition=_try_parse_log_level,
+            ),
+            Validator(
+                "RUNTIME.EXCEPTIONS.DEFAULTS.GLOBAL",
+                required=True,
+                apply_default_on_none=True,
+                default="nexus_client_sdk.nexus.exceptions._nexus_error.FatalNexusError",
+            ),
+            Validator(
+                "RUNTIME.EXCEPTIONS.SCOPED",
+                apply_default_on_none=True,
+                default=[
+                    {
+                        "class_name": "nexus_client_sdk.nexus.abstractions.algorithm_cache.InputCache",
+                        "errors": [
+                            "cassandra.Timeout",
+                            "cassandra.Unavailable",
+                            "cassandra.ReadTimeout",
+                            "cassandra.WriteTimeout",
+                            "cassandra.OperationTimedOut",
+                            "cassandra.ReadFailure",
+                            "cassandra.CoordinationFailure",
+                        ],
+                        "target": "nexus_client_sdk.nexus.exceptions.cache_errors.TransientCachingError",
+                    },
+                    {
+                        "class_name": "nexus_client_sdk.nexus.abstractions.algorithm_cache.InputCache",
+                        "errors": [
+                            "cassandra.Unauthorized",
+                            "cassandra.RequestValidationException",
+                            "cassandra.AuthenticationFailed",
+                        ],
+                        "target": "nexus_client_sdk.nexus.exceptions.cache_errors.FatalCachingError",
+                    },
+                    {
+                        "class_name": "nexus_client_sdk.nexus.abstractions.algorithm_cache.InputCache",
+                        "errors": [],
+                        "target": "nexus_client_sdk.nexus.exceptions.cache_errors.FatalCachingError",
+                    },
+                ],
+                condition=_try_locate_error_classes,
             ),
         ]
 

--- a/nexus_client_sdk/nexus/configurations/settings.toml
+++ b/nexus_client_sdk/nexus/configurations/settings.toml
@@ -38,6 +38,50 @@ metric_tagging_function = ""
 # implementations of NexusConfiguration to be read from system environment
 configuration_types = []
 
+# Manage applicaton response to various error types
+[runtime.exceptions]
+
+# default error to use for remapping
+[runtime.exceptions.defaults]
+global_default = 'nexus_client_sdk.nexus.exceptions._nexus_error.FatalNexusError'
+
+# class-scoped exceptions
+[[runtime.exceptions.scoped]]
+# fully qualified class name (module name + name)
+class_name = 'nexus_client_sdk.nexus.abstractions.algorithm_cache.InputCache'
+# errors to remap. provide [] to remap all errors to an alternative default
+errors = [
+    'cassandra.Timeout',
+    'cassandra.Unavailable',
+    'cassandra.ReadTimeout',
+    'cassandra.WriteTimeout',
+    'cassandra.OperationTimedOut',
+    'cassandra.ReadFailure',
+    'cassandra.CoordinationFailure'
+]
+# target error to remap to
+target = 'nexus_client_sdk.nexus.exceptions.cache_errors.TransientCachingError'
+
+[[runtime.exceptions.scoped]]
+# fully qualified class name (module name + name)
+class_name = 'nexus_client_sdk.nexus.abstractions.algorithm_cache.InputCache'
+# errors to remap. provide [] to remap all errors to an alternative default
+errors = [
+    'cassandra.Unauthorized',
+    'cassandra.RequestValidationException',
+    'cassandra.AuthenticationFailed'
+]
+# target error to remap to
+target = 'nexus_client_sdk.nexus.exceptions.cache_errors.FatalCachingError'
+
+[[runtime.exceptions.scoped]]
+# fully qualified class name (module name + name)
+class_name = 'nexus_client_sdk.nexus.abstractions.algorithm_cache.InputCache'
+# [] remaps errors that didn't match any other list to an alternative default
+errors = []
+# target error to remap to
+target = 'nexus_client_sdk.nexus.exceptions.cache_errors.FatalCachingError'
+
 # Nexus client configuration
 [client]
 # Nexus Receiver address

--- a/nexus_client_sdk/nexus/core/app_dependencies.py
+++ b/nexus_client_sdk/nexus/core/app_dependencies.py
@@ -37,6 +37,7 @@ from nexus_client_sdk.nexus.core.serializers import (
     TelemetrySerializer,
     ResultSerializer,
 )
+from nexus_client_sdk.nexus.exceptions.error_map import NexusErrorMapCollection, NexusErrorMap
 from nexus_client_sdk.nexus.exceptions.startup_error import (
     FatalStartupConfigurationError,
 )
@@ -171,7 +172,26 @@ class CacheModule(Module):
         """
         Dependency provider.
         """
-        return InputCache()
+        loaded_error_map: dict[str, list[NexusErrorMap]] = {}
+        for error_map_config in NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.exceptions.scoped:
+            if error_map_config["class_name"] not in loaded_error_map:
+                loaded_error_map[error_map_config["class_name"]] = [NexusErrorMap.from_config(error_map_config)]
+            else:
+                loaded_error_map[error_map_config["class_name"]].append(NexusErrorMap.from_config(error_map_config))
+
+        default_error: type[BaseException] = locate(
+            NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.exceptions.defaults.global_default
+        )
+        if default_error is None:
+            raise FatalStartupConfigurationError(
+                f"Unable to locate default error map class: {NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.exceptions.defaults.global_default}"
+            )
+
+        map_instance = NexusErrorMapCollection(
+            global_default=default_error,
+            error_map=loaded_error_map,
+        )
+        return InputCache(map_instance)
 
 
 @final

--- a/nexus_client_sdk/nexus/exceptions/error_map.py
+++ b/nexus_client_sdk/nexus/exceptions/error_map.py
@@ -29,8 +29,13 @@ class NexusErrorMap:
 
     @classmethod
     def from_config(cls, value: dict) -> Self:
+        """
+         Creates an instance of NexusErrorMap from the provided dictionary.
+        :param value:
+        :return:
+        """
         target: type[BaseException] = locate(value["target"])
-        errors: list[type[BaseException]] = list(map(lambda error_path: locate(error_path), value["errors"]))
+        errors: list[type[BaseException]] = list(map(locate, value["errors"]))
 
         return cls(target, errors)
 

--- a/nexus_client_sdk/nexus/exceptions/error_map.py
+++ b/nexus_client_sdk/nexus/exceptions/error_map.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+from pydoc import locate
+from typing import final, Self
+
+
+@final
+@dataclass
+class NexusErrorMap:
+    """
+    Remapped exception definition
+    """
+
+    target: type[BaseException]
+    errors: list[type[BaseException]]
+
+    def map_exception(self, ex: BaseException) -> type[BaseException] | None:
+        """
+        Try to map an exception using internal errors list.
+        """
+        # empty list means default remap for any exception
+        if len(self.errors) == 0:
+            return self.target
+
+        for source_error in self.errors:
+            if isinstance(ex, source_error):
+                return self.target
+
+        return None
+
+    @classmethod
+    def from_config(cls, value: dict) -> Self:
+        target: type[BaseException] = locate(value["target"])
+        errors: list[type[BaseException]] = list(map(lambda error_path: locate(error_path), value["errors"]))
+
+        return cls(target, errors)
+
+
+@final
+class NexusErrorMapCollection:
+    """
+    Error map for Fatal/Transient Nexus errors
+    """
+
+    def __init__(self, global_default: type[BaseException], error_map: dict[str, list[NexusErrorMap]]) -> None:
+        self._global_default = global_default
+        self._error_map = error_map or {}
+
+    def map_error(self, ex: BaseException, caller: type) -> type[BaseException]:
+        """
+         Map a provided exception to a different one, using the configured collection.
+        :param ex: Error to be mapped
+        :param caller: __class__ attribute of the caller instance
+        """
+
+        def _get_caller_fqn() -> str:
+            return f"{caller.__module__}.{caller.__qualname__}"
+
+        caller_fqn = _get_caller_fqn()
+        if caller_fqn in self._error_map:
+            for error_map_entry in self._error_map[caller_fqn]:
+                mapped_ex = error_map_entry.map_exception(ex)
+                if mapped_ex:
+                    return mapped_ex
+
+        return self._global_default

--- a/tests/settings.custom.toml
+++ b/tests/settings.custom.toml
@@ -35,6 +35,50 @@ configuration_types = [
     "tests.conftest.TestAlgorithmConfiguration"
 ]
 
+# Manage applicaton response to various error types
+[runtime.exceptions]
+
+# default error to use for remapping
+[runtime.exceptions.defaults]
+global_default = 'nexus_client_sdk.nexus.exceptions._nexus_error.FatalNexusError'
+
+# class-scoped exceptions
+[[runtime.exceptions.scoped]]
+# fully qualified class name (module name + name)
+class_name = 'nexus_client_sdk.nexus.abstractions.algorithm_cache.InputCache'
+# errors to remap. provide [] to remap all errors to an alternative default
+errors = [
+    'cassandra.Timeout',
+    'cassandra.Unavailable',
+    'cassandra.ReadTimeout',
+    'cassandra.WriteTimeout',
+    'cassandra.OperationTimedOut',
+    'cassandra.ReadFailure',
+    'cassandra.CoordinationFailure'
+]
+# target error to remap to
+target = 'nexus_client_sdk.nexus.exceptions.cache_errors.TransientCachingError'
+
+[[runtime.exceptions.scoped]]
+# fully qualified class name (module name + name)
+class_name = 'nexus_client_sdk.nexus.abstractions.algorithm_cache.InputCache'
+# errors to remap. provide [] to remap all errors to an alternative default
+errors = [
+    'cassandra.Unauthorized',
+    'cassandra.RequestValidationException',
+    'cassandra.AuthenticationFailed'
+]
+# target error to remap to
+target = 'nexus_client_sdk.nexus.exceptions.cache_errors.FatalCachingError'
+
+[[runtime.exceptions.scoped]]
+# fully qualified class name (module name + name)
+class_name = 'nexus_client_sdk.nexus.abstractions.algorithm_cache.InputCache'
+# [] remaps errors that didn't match any other list to an alternative default
+errors = []
+# target error to remap to
+target = 'nexus_client_sdk.nexus.exceptions.cache_errors.FatalCachingError'
+
 # Result processing and serialization
 [result]
 


### PR DESCRIPTION
Closes https://github.com/SneaksAndData/nexus-sdk-py/issues/93

Configurable error remapping mechanism. Exception mapping to `XXXNexusXXX` errors can now managed and extended via configuration instead of hardcoded logic. `InputCache` exception mapping updated accordingly.

**Configurable Error Remapping:**
* Added TOML configuration options (`settings.toml`, `tests/settings.custom.toml`) for specifying global default errors and class-scoped error remapping rules under `[runtime.exceptions]`, allowing the mapping of specific exceptions to target error types.
* Updated `NexusRuntimeConfiguration` to include validators for new config entries to ensure error classes are *importable*

**Error Mapping Implementation:**
* Introduced `NexusErrorMap` and `NexusErrorMapCollection` classes in `nexus/exceptions/error_map.py` to encapsulate the mapping logic, including dynamic resolution of exception classes and mapping based on configuration.

**Integration with InputCache:**
* Refactored `InputCache` to receive an error map collection and delegate exception type resolution to it, removing hardcoded exception handling for Cassandra and DeltaLake errors. Clients will need to update their configurations to include relevant errors.
* Updated dependency injection in `app_dependencies.py` to construct and inject the configured error map collection into `InputCache`, raising a startup error if the default error class cannot be located.

**AI Summary - edited**