### PR TITLE
run NEXUS_FRAMEWORK_CONFIGURATION.load() at the start of NEXUS constructor

### DIFF
--- a/nexus_client_sdk/nexus/core/app_core.py
+++ b/nexus_client_sdk/nexus/core/app_core.py
@@ -103,6 +103,7 @@ class Nexus:
     """
 
     def __init__(self, args: NexusDefaultArguments):
+        NEXUS_FRAMEWORK_CONFIGURATION.load()
         self._injector: Injector | None = None
         self._run_args = args
         self._algorithm_run_task: asyncio.Task | None = None
@@ -238,7 +239,6 @@ class Nexus:
         """
         Activates the run sequence.
         """
-        NEXUS_FRAMEWORK_CONFIGURATION.load()
 
         # configure blocking pool
         loop = asyncio.get_event_loop()

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -55,7 +55,9 @@ async def test_sdk_run(test_args: NexusDefaultArguments, scheduler: NexusSchedul
 
 @pytest.mark.asyncio(loop_scope="package")
 @pytest.mark.parametrize("test_args", test_cases)
-async def test_sdk_run_no_config_preload(test_args: NexusDefaultArguments, scheduler: NexusSchedulerClient, cql_session: Session) -> None:
+async def test_sdk_run_no_config_preload(
+    test_args: NexusDefaultArguments, scheduler: NexusSchedulerClient, cql_session: Session
+) -> None:
     algorithm = "hello-world"
     # create initial fake record
     cql_session.execute(
@@ -69,6 +71,7 @@ async def test_sdk_run_no_config_preload(test_args: NexusDefaultArguments, sched
     assert (
         result["total_executed_by_cache"] == 5 and run_meta.payload_uri
     )  # expect 1 run of each: XYSAMPLE, ZSAMPLE, ZPROCESSOR, ZZPROCESSOR, XYPROCESSOR
+
 
 @pytest.mark.asyncio(loop_scope="package")
 @pytest.mark.parametrize("test_args", compressed_test_cases)

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -54,6 +54,23 @@ async def test_sdk_run(test_args: NexusDefaultArguments, scheduler: NexusSchedul
 
 
 @pytest.mark.asyncio(loop_scope="package")
+@pytest.mark.parametrize("test_args", test_cases)
+async def test_sdk_run_no_config_preload(test_args: NexusDefaultArguments, scheduler: NexusSchedulerClient, cql_session: Session) -> None:
+    algorithm = "hello-world"
+    # create initial fake record
+    cql_session.execute(
+        f"INSERT INTO nexus.checkpoints (algorithm, id, lifecycle_stage, payload_uri, applied_configuration, configuration_overrides, parent) VALUES ('{algorithm}', '{test_args.request_id}', 'RUNNING', '{test_args.sas_uri}', '{runtime_config_stub}', '{{}}', '{{}}')"
+    )
+    sys.argv = ["", "--sas-uri", test_args.sas_uri, "--request-id", test_args.request_id]
+    await sample_algorithm_main()
+    await asyncio.sleep(1)
+    result = json.loads(requests.get(scheduler.get_run_result(test_args.request_id, algorithm).result_uri).text)
+    run_meta = scheduler.get_request_metadata(test_args.request_id, algorithm)
+    assert (
+        result["total_executed_by_cache"] == 5 and run_meta.payload_uri
+    )  # expect 1 run of each: XYSAMPLE, ZSAMPLE, ZPROCESSOR, ZZPROCESSOR, XYPROCESSOR
+
+@pytest.mark.asyncio(loop_scope="package")
 @pytest.mark.parametrize("test_args", compressed_test_cases)
 async def test_sdk_run_compressed(
     test_args: NexusDefaultArguments, scheduler: NexusSchedulerClient, cql_session: Session


### PR DESCRIPTION
Fixes issue #195. Upon calling Nexus.create() the bootstrap procedures fails because NEXUS_FRAMEWORK_CONFIGURATION.load() is not called before entering BootstrapLoggerFactory.__init__() and as such NEXUS_FRAMEWORK_CONFIGURATION.default is Nonetype, which causes an exception.

## Scope

Implemented:
 - NEXUS_FRAMEWORK_CONFIGURATION.load() at the start of NEXUS constructor

Additional changes:
- Introduced test case without preloading NEXUS_FRAMEWORK_CONFIGURATION.load()

## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [x] Review requested on `latest` commit.
