### PR TITLE
[Bootstrap] Initialize bootstrap logger correctly

### DIFF
--- a/nexus_client_sdk/nexus/core/app_bootstrap.py
+++ b/nexus_client_sdk/nexus/core/app_bootstrap.py
@@ -56,6 +56,8 @@ class NexusBootstrapper:
     """
 
     def __init__(self, run_args: NexusDefaultArguments):
+        self._logger_factory: BootstrapLoggerFactory | None = None
+        self._logger: LoggerInterface | None = None
         self._injection_binds = [
             BootstrapLoggerFactoryModule(),
             StorageClientModule(),

--- a/nexus_client_sdk/nexus/core/app_bootstrap.py
+++ b/nexus_client_sdk/nexus/core/app_bootstrap.py
@@ -56,11 +56,6 @@ class NexusBootstrapper:
     """
 
     def __init__(self, run_args: NexusDefaultArguments):
-        self._logger_factory = BootstrapLoggerFactory()
-        self._logger = self._logger_factory.create_logger(
-            request_id=run_args.request_id,
-            algorithm_name=NEXUS_FRAMEWORK_CONFIGURATION.default.algorithm_name,
-        )
         self._injection_binds = [
             BootstrapLoggerFactoryModule(),
             StorageClientModule(),
@@ -227,6 +222,11 @@ class NexusBootstrapper:
         return None
 
     async def __aenter__(self):
+        self._logger_factory = BootstrapLoggerFactory()
+        self._logger = self._logger_factory.create_logger(
+            request_id=self._run_args.request_id,
+            algorithm_name=NEXUS_FRAMEWORK_CONFIGURATION.default.algorithm_name,
+        )
         self._logger.start()
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -37,8 +37,7 @@ runtime_config_stub = (
 @pytest.mark.asyncio(loop_scope="package")
 @pytest.mark.parametrize("test_args", test_cases)
 async def test_sdk_run(test_args: NexusDefaultArguments, scheduler: NexusSchedulerClient, cql_session: Session) -> None:
-    NEXUS_FRAMEWORK_CONFIGURATION.load()
-    algorithm = NEXUS_FRAMEWORK_CONFIGURATION.default.algorithm_name
+    algorithm = "hello-world"  # do not force load config, so bootstrapping can be covered properly
     # create initial fake record
     cql_session.execute(
         f"INSERT INTO nexus.checkpoints (algorithm, id, lifecycle_stage, payload_uri, applied_configuration, configuration_overrides, parent) VALUES ('{algorithm}', '{test_args.request_id}', 'RUNNING', '{test_args.sas_uri}', '{runtime_config_stub}', '{{}}', '{{}}')"


### PR DESCRIPTION
Related to https://github.com/SneaksAndData/nexus-sdk-py/pull/196

For context, CI didn't catch this because we call `NEXUS_FRAMEWORK_CONFIGURATION.load()` on test startup.