### PR TITLE
Small bugfix for payload telemetry

### DIFF
--- a/nexus_client_sdk/nexus/telemetry/payload_recorder.py
+++ b/nexus_client_sdk/nexus/telemetry/payload_recorder.py
@@ -39,7 +39,7 @@ class PayloadTelemetry(UserTelemetryRecorder[str, AlgorithmResult]):
                 [
                     DataFrame(
                         {
-                            "payload": algorithm_result.result()["data"],
+                            "payload": algorithm_result.result()["content"],
                             "request_id": run_id,
                             "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                             "is_valid": True,
@@ -75,11 +75,11 @@ class FailedPayloadRecorder(UserTelemetryRecorder[str, AlgorithmResult]):
                 [
                     DataFrame(
                         {
-                            "payload": algorithm_result.result()["data"],
+                            "payload": algorithm_result.result()["content"],
                             "request_id": run_id,
                             "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                             "is_valid": False,
-                        }
+
                     )
                 ]
             )

--- a/nexus_client_sdk/nexus/telemetry/payload_recorder.py
+++ b/nexus_client_sdk/nexus/telemetry/payload_recorder.py
@@ -79,7 +79,7 @@ class FailedPayloadRecorder(UserTelemetryRecorder[str, AlgorithmResult]):
                             "request_id": run_id,
                             "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                             "is_valid": False,
-
+                        }
                     )
                 ]
             )


### PR DESCRIPTION
Fixes/Implements #<issue number>.

## Scope

The key of the payload content was "data" and it should have been "content"

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [ ] Review requested on `latest` commit.
