### PR TITLE
BUG-FIX: Fix payload telemetry recorders

### DIFF
--- a/nexus_client_sdk/nexus/telemetry/payload_recorder.py
+++ b/nexus_client_sdk/nexus/telemetry/payload_recorder.py
@@ -39,10 +39,10 @@ class PayloadTelemetry(UserTelemetryRecorder[str, AlgorithmResult]):
                 [
                     DataFrame(
                         {
-                            "payload": algorithm_result.result()["content"],
-                            "request_id": run_id,
-                            "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                            "is_valid": True,
+                            "payload": [algorithm_result.result()["content"]],
+                            "request_id": [run_id],
+                            "recorded_at": [datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")],
+                            "is_valid": [True],
                         }
                     )
                 ]
@@ -75,10 +75,10 @@ class FailedPayloadRecorder(UserTelemetryRecorder[str, AlgorithmResult]):
                 [
                     DataFrame(
                         {
-                            "payload": algorithm_result.result()["content"],
-                            "request_id": run_id,
-                            "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                            "is_valid": False,
+                            "payload": [algorithm_result.result()["content"]],
+                            "request_id": [run_id],
+                            "recorded_at": [datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")],
+                            "is_valid": [False],
                         }
                     )
                 ]


### PR DESCRIPTION
Got this log from my algorithm when using the payload telemetry recorder:
```ValueError: If using all scalar values, you must pass an index```

Hence, Pandas is not smart enough to figure out that this is a dataframe with 1 row. E.g. this won't work:
```python: 
pandas.DataFrame({"column": "value"})
```
While this will:
```python: 
pandas.DataFrame({"column": ["value"]})
```