### PR TITLE
fix: remove -x from set -euxo pipefail to prevent secret leakage

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -30,10 +30,10 @@ jobs:
         env:
           PROJECT_NAME: nexus_client_sdk
         run: |
-          set -euxo pipefail
+          set -euo pipefail
           find "$PROJECT_NAME" -type f -name "*.py" | xargs poetry run pylint
 
       - name: Black
         run: |
-          set -euxo pipefail
+          set -euo pipefail
           poetry run black . --check --diff

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
           NEXUS__SDK_LOG_LEVEL: INFO
           ROOT_PATH_FOR_DYNACONF: ${{ github.workspace }}/tests
         run: |
-          set -euxo pipefail
+          set -euo pipefail
           
           poetry run pytest -n auto --dist loadgroup --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=term-missing:skip-covered | tee pytest-coverage.txt
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,7 +83,7 @@ jobs:
         env:
           VERSION: ${{steps.version.outputs.version}}
         run: |
-          set -euxo pipefail
+          set -euo pipefail
 
           curl -sSL https://install.python-poetry.org | python3 -
           
@@ -138,7 +138,7 @@ jobs:
         env:
           VERSION: ${{steps.version.outputs.version}}
         run: |
-          set -euxo pipefail
+          set -euo pipefail
 
           curl -sSL https://install.python-poetry.org | python3 -
           


### PR DESCRIPTION
## Summary

Removes the `-x` flag from `set -euxo pipefail` to prevent secrets from being printed in GitHub Actions logs.

The `-x` flag causes bash to print each command before executing it, which can expose secret values that are passed as environment variables or arguments.

## Related Issue

Closes SneaksAndData/terraform#7626

## Changes

- Replaced `set -euxo pipefail` with `set -euo pipefail` in affected workflow files
