### PR TITLE
Add support for remote payload specific tags

### DIFF
--- a/nexus_client_sdk/nexus/algorithms/_remote_algorithm.py
+++ b/nexus_client_sdk/nexus/algorithms/_remote_algorithm.py
@@ -72,7 +72,7 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
         :param remote_client: NexusSchedulerAsyncClient instance to use. Provided from DI, do not initialize manually.
         :param remote_name: Name of the remote algorithm to use.
         :param is_hard_dependency: If set to True, the launched run will set the initiator as Parent. Cancelling or completing the Parent will lead to remote run being aborted. If set to False, no Parent-Child relationship will be created. However, you can still override _generate_tag to retain the parent reference. Defaults to False.
-        :param force_run: If set to True, the launch will be made no matter what. If set to False, it will be checked whether remote algorithm tag already exists already exists before spawning to avoid dublicated spawns.
+        :param force_run: If set to True, the launch will be made no matter what. If set to False, it will be checked whether remote algorithm tag already exists before spawning to avoid dublicated runs.
         :param input_processors: Inputs to use for payload generation
         :param remote_config: Optional configuration for remote execution
         :param compressor: Optional compressor to use for payload generation. Provided from DI, do not initialize manually.
@@ -99,8 +99,8 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
     @abstractmethod
     def _generate_tag_from_remote_payload(self, payload: AlgorithmPayload, **kwargs) -> str | None:
         """
-        Generates a submission tag specific to a remove payload.
-        If not implemented by subclass, _generate_tag() is used as tag all remote algorithms.
+        Generates a submission tag specific to a remote payload.
+        If not implemented by subclass, _generate_tag() is used as tag for all remote algorithm runs.
         """
         return None
 

--- a/nexus_client_sdk/nexus/algorithms/_remote_algorithm.py
+++ b/nexus_client_sdk/nexus/algorithms/_remote_algorithm.py
@@ -203,7 +203,7 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
                 self._logger.info(
                     "Found existing runs with tag {tag} for remote algorithm {remote_algorithm}, reusing the latest "
                     "received one with request_id: {old_request_id}."
-                    "\nJson payload skipped spawn is: {algorithm_parameters}",
+                    "\payload for this request is: {algorithm_parameters}",
                     tag=tag,
                     remote_algorithm=self._remote_name,
                     old_request_id=run_metadata[-1].id,

--- a/nexus_client_sdk/nexus/algorithms/_remote_algorithm.py
+++ b/nexus_client_sdk/nexus/algorithms/_remote_algorithm.py
@@ -93,6 +93,14 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
         """
 
     @abstractmethod
+    def _generate_tag_from_remote_payloaod(self, payload: AlgorithmPayload, **kwargs) -> str | None:
+        """
+        Generates a submission tag specific to a remove payload.
+        If not implemented by subclass, _generate_tag() is used as tag all remote algorithms.
+        """
+        return None
+
+    @abstractmethod
     def _transform_submission_result(self, request_ids: list[str], tag: str) -> AlgorithmResult:
         """
         Called after submitting a remote run. Use this to enrich your output with remote run id and tag.
@@ -143,7 +151,14 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
             payloads = await self._run(**run_args)
             tag = self._generate_tag(**run_args)
 
-            request_ids = [await self._create_remote_run(payload=payload, tag=tag, **run_args) for payload in payloads]
+            request_ids = [
+                await self._create_remote_run(
+                    payload=payload,
+                    tag=self._generate_tag_from_remote_payloaod(payload=payload, **run_args) or tag,
+                    **run_args,
+                )
+                for payload in payloads
+            ]
 
             return self._transform_submission_result(request_ids, tag)
 

--- a/nexus_client_sdk/nexus/algorithms/_remote_algorithm.py
+++ b/nexus_client_sdk/nexus/algorithms/_remote_algorithm.py
@@ -93,7 +93,7 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
         """
 
     @abstractmethod
-    def _generate_tag_from_remote_payloaod(self, payload: AlgorithmPayload, **kwargs) -> str | None:
+    def _generate_tag_from_remote_payload(self, payload: AlgorithmPayload, **kwargs) -> str | None:
         """
         Generates a submission tag specific to a remove payload.
         If not implemented by subclass, _generate_tag() is used as tag all remote algorithms.
@@ -154,7 +154,7 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
             request_ids = [
                 await self._create_remote_run(
                     payload=payload,
-                    tag=self._generate_tag_from_remote_payloaod(payload=payload, **run_args) or tag,
+                    tag=self._generate_tag_from_remote_payload(payload=payload, **run_args) or tag,
                     **run_args,
                 )
                 for payload in payloads

--- a/nexus_client_sdk/nexus/algorithms/_remote_algorithm.py
+++ b/nexus_client_sdk/nexus/algorithms/_remote_algorithm.py
@@ -18,6 +18,7 @@
 #
 
 from abc import abstractmethod
+import json
 import base64
 from functools import partial
 
@@ -26,7 +27,7 @@ from adapta.storage.models.formatters import DictJsonSerializationFormat
 from adapta.utils.decorators import run_time_metrics_async
 from injector import inject
 
-from nexus_client_sdk.models.scheduler import SdkCustomRunConfiguration, SdkParentRequest
+from nexus_client_sdk.models.scheduler import SdkCustomRunConfiguration, SdkParentRequest, RequestMetadata
 from nexus_client_sdk.nexus.abstractions.algorithm_cache import InputCache
 from nexus_client_sdk.nexus.abstractions.nexus_object import (
     NexusObject,
@@ -58,6 +59,7 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
         remote_name: str,
         *input_processors: InputProcessor,
         is_hard_dependency: bool = False,
+        force_run: bool = True,
         remote_config: SdkCustomRunConfiguration | None = None,
         compressor: Compressor | None = None,
         compress_payload: bool = False,
@@ -70,6 +72,7 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
         :param remote_client: NexusSchedulerAsyncClient instance to use. Provided from DI, do not initialize manually.
         :param remote_name: Name of the remote algorithm to use.
         :param is_hard_dependency: If set to True, the launched run will set the initiator as Parent. Cancelling or completing the Parent will lead to remote run being aborted. If set to False, no Parent-Child relationship will be created. However, you can still override _generate_tag to retain the parent reference. Defaults to False.
+        :param force_run: If set to True, the launch will be made no matter what. If set to False, it will be checked whether remote algorithm tag already exists already exists before spawning to avoid dublicated spawns.
         :param input_processors: Inputs to use for payload generation
         :param remote_config: Optional configuration for remote execution
         :param compressor: Optional compressor to use for payload generation. Provided from DI, do not initialize manually.
@@ -85,6 +88,7 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
         self._compressor = compressor
         self._compress_payload = compress_payload
         self._is_hard_dependency = is_hard_dependency
+        self._force_run = force_run
 
     @abstractmethod
     def _generate_tag(self, **kwargs) -> str:
@@ -178,10 +182,38 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
         Creates a fork run for the given payload and tag.
         """
 
-        request_id = await self._remote_client.create_run(
-            algorithm_parameters=self._compress_remote_payload(payload=payload)
+        algorithm_parameters = (
+            self._compress_remote_payload(payload=payload)
             if self._compress_payload
-            else DictJsonSerializationFormat().deserialize(payload.to_json().encode(encoding="utf-8")),
+            else DictJsonSerializationFormat().deserialize(payload.to_json().encode(encoding="utf-8"))
+        )
+
+        if not self._force_run:
+            run_results = self._remote_client.get_run_results(tag=tag, algorithm=self._remote_name)
+
+            run_metadata: list[RequestMetadata] = sorted(
+                [
+                    self._remote_client.get_request_metadata(request_id=result.request_id, algorithm=self._remote_name)
+                    for result in run_results
+                ],
+                key=lambda x: x.received_at,
+            )
+
+            if run_metadata:
+                self._logger.info(
+                    "Found existing runs with tag {tag} for remote algorithm {remote_algorithm}, reusing the latest "
+                    "received one with request_id: {old_request_id}."
+                    "\nJson payload skipped spawn is: {algorithm_parameters}",
+                    tag=tag,
+                    remote_algorithm=self._remote_name,
+                    old_request_id=run_metadata[-1].id,
+                    algorithm_parameters=json.dumps(algorithm_parameters),
+                )
+
+                return run_metadata[-1].id
+
+        request_id = await self._remote_client.create_run(
+            algorithm_parameters=algorithm_parameters,
             algorithm_name=self._remote_name,
             custom_configuration=self._remote_config,
             parent_request=SdkParentRequest.create(

--- a/nexus_client_sdk/nexus/algorithms/_remote_algorithm.py
+++ b/nexus_client_sdk/nexus/algorithms/_remote_algorithm.py
@@ -72,7 +72,7 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
         :param remote_client: NexusSchedulerAsyncClient instance to use. Provided from DI, do not initialize manually.
         :param remote_name: Name of the remote algorithm to use.
         :param is_hard_dependency: If set to True, the launched run will set the initiator as Parent. Cancelling or completing the Parent will lead to remote run being aborted. If set to False, no Parent-Child relationship will be created. However, you can still override _generate_tag to retain the parent reference. Defaults to False.
-        :param force_run: If set to True, the launch will be made no matter what. If set to False, it will be checked whether remote algorithm tag already exists before spawning to avoid dublicated runs.
+        :param force_run: If set to True, the launch will be made no matter what. If set to False, it will be checked whether remote algorithm tag already exists before spawning to avoid duplicated runs.
         :param input_processors: Inputs to use for payload generation
         :param remote_config: Optional configuration for remote execution
         :param compressor: Optional compressor to use for payload generation. Provided from DI, do not initialize manually.
@@ -96,7 +96,7 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
         Generates a submission tag.
         """
 
-    @abstractmethod
+    # pylint: disable=unused-argument
     def _generate_tag_from_remote_payload(self, payload: AlgorithmPayload, **kwargs) -> str | None:
         """
         Generates a submission tag specific to a remote payload.
@@ -203,7 +203,7 @@ class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
                 self._logger.info(
                     "Found existing runs with tag {tag} for remote algorithm {remote_algorithm}, reusing the latest "
                     "received one with request_id: {old_request_id}."
-                    "\payload for this request is: {algorithm_parameters}",
+                    "\npayload for this request is: {algorithm_parameters}",
                     tag=tag,
                     remote_algorithm=self._remote_name,
                     old_request_id=run_metadata[-1].id,

--- a/nexus_client_sdk/nexus/async_extensions/nexus_scheduler_async_client.py
+++ b/nexus_client_sdk/nexus/async_extensions/nexus_scheduler_async_client.py
@@ -15,7 +15,7 @@
 #  limitations under the License.
 #
 
-from typing import final, Any
+from typing import final, Any, Iterator
 from collections.abc import Callable
 from functools import partial
 
@@ -220,7 +220,7 @@ class NexusSchedulerAsyncClient:
             method_alias="get_request_metadata",
         )
 
-    async def get_run_results(self, tag: str, algorithm: str | None = None) -> RequestMetadata | None:
+    async def get_run_results(self, tag: str, algorithm: str | None = None) -> Iterator[RunResult]:
         """
         Retrieves run results for a given tag.
         :param tag: Client-side assigned run tag.

--- a/nexus_client_sdk/nexus/async_extensions/nexus_scheduler_async_client.py
+++ b/nexus_client_sdk/nexus/async_extensions/nexus_scheduler_async_client.py
@@ -219,3 +219,23 @@ class NexusSchedulerAsyncClient:
             f"Fatal error when getting metadata for request {algorithm}/{request_id}",
             method_alias="get_request_metadata",
         )
+
+    async def get_run_results(self, tag: str, algorithm: str | None = None) -> RequestMetadata | None:
+        """
+        Retrieves run results for a given tag.
+        :param tag: Client-side assigned run tag.
+        :param algorithm: Optional algorithm to filter returned results by.
+        :return: Run result collection.
+        """
+
+        return await self._retry_policy_builder.build().execute(
+            lambda: run_blocking(
+                partial(
+                    self._sync_client.get_run_results,
+                    tag=tag,
+                    algorithm=algorithm,
+                )
+            ),
+            f"Fatal error when getting run results for requests with tag {algorithm}/{tag}",
+            method_alias="get_run_results",
+        )

--- a/tests/nexus/algorithms/test_remote_algorithm.py
+++ b/tests/nexus/algorithms/test_remote_algorithm.py
@@ -129,6 +129,9 @@ class TestRemoteAlgorithm(RemoteAlgorithm):
     def _generate_tag(self, **_) -> str:
         return "test-tag"
 
+    def _generate_tag_from_remote_payloaod(self, payload: SimpleTestPayload, **kwargs) -> str | None:
+        return "test-tag-" + payload.test_id
+
     async def _run(self, **kwargs):
         return []
 

--- a/tests/nexus/algorithms/test_remote_algorithm.py
+++ b/tests/nexus/algorithms/test_remote_algorithm.py
@@ -129,7 +129,7 @@ class TestRemoteAlgorithm(RemoteAlgorithm):
     def _generate_tag(self, **_) -> str:
         return "test-tag"
 
-    def _generate_tag_from_remote_payloaod(self, payload: SimpleTestPayload, **kwargs) -> str | None:
+    def _generate_tag_from_remote_payload(self, payload: SimpleTestPayload, **kwargs) -> str | None:
         return "test-tag-" + payload.test_id
 
     async def _run(self, **kwargs):


### PR DESCRIPTION
## What
- Add create tag method from remote payload 
- Ensure ```_create_remote_run``` does not spawn if tag exists and ```_force_run=False```. 
## Why
Idea is to create a tag from remote payload such that users can ensure same unique tag is generated if same request is running multiple times. This tag is then used in combination with ```_force_run=False``` to ensure job is not spawned if tag already exists. 
```_force_run``` default to ```True``` to ensure backwards compatibility. 