### PR TITLE
Support dynamic socket override from a specialized payload

### DIFF
--- a/nexus_client_sdk/nexus/abstractions/socket_provider.py
+++ b/nexus_client_sdk/nexus/abstractions/socket_provider.py
@@ -18,7 +18,7 @@
 #
 
 import json
-import warnings
+from typing_extensions import deprecated
 from typing import final, Self, TypeVar
 
 import dynaconf
@@ -113,7 +113,7 @@ class SocketCollection:
 
 
 @final
-@warnings.deprecated("This module is deprecated and will be removed in 1.7. Use SocketCollection instead.")
+@deprecated("This module is deprecated and will be removed in 1.7. Use SocketCollection instead.")
 class ExternalSocketProvider:
     """
     Wraps a socket collection

--- a/nexus_client_sdk/nexus/abstractions/socket_provider.py
+++ b/nexus_client_sdk/nexus/abstractions/socket_provider.py
@@ -31,10 +31,6 @@ from nexus_client_sdk.nexus.exceptions.startup_error import (
 _TSocket = TypeVar("_TSocket", bound=DataSocket)
 
 
-def _from_generic_socket(socket: DataSocket, _: type[_TSocket]) -> _TSocket:
-    return socket
-
-
 @final
 class InputSocket(DataSocket):
     """

--- a/nexus_client_sdk/nexus/abstractions/socket_provider.py
+++ b/nexus_client_sdk/nexus/abstractions/socket_provider.py
@@ -18,8 +18,8 @@
 #
 
 import json
-from typing_extensions import deprecated
 from typing import final, Self, TypeVar
+from typing_extensions import deprecated
 
 import dynaconf
 from adapta.process_communication import DataSocket

--- a/nexus_client_sdk/nexus/abstractions/socket_provider.py
+++ b/nexus_client_sdk/nexus/abstractions/socket_provider.py
@@ -18,7 +18,8 @@
 #
 
 import json
-from typing import final, Self
+import warnings
+from typing import final, Self, TypeVar
 
 import dynaconf
 from adapta.process_communication import DataSocket
@@ -27,8 +28,96 @@ from nexus_client_sdk.nexus.exceptions.startup_error import (
     FatalStartupConfigurationError,
 )
 
+_TSocket = TypeVar("_TSocket", bound=DataSocket)
+
+
+def _from_generic_socket(socket: DataSocket, _: type[_TSocket]) -> _TSocket:
+    return socket
+
 
 @final
+class InputSocket(DataSocket):
+    """
+    Read-only DataSocket.
+    """
+
+
+@final
+class OutputSocket(DataSocket):
+    """
+    Write-only DataSocket.
+    """
+
+
+@final
+class SocketCollection:
+    """
+    Input and output sockets loaded from configuration and payloads.
+    """
+
+    def __init__(self, input_sockets: list[InputSocket], output_sockets: list[OutputSocket]):
+        self._input_sockets = {socket.alias: socket for socket in input_sockets}
+        self._output_sockets = {socket.alias: socket for socket in output_sockets}
+
+    def _try_get_socket(self, name: str, sockets: dict[str, _TSocket]) -> _TSocket:
+        if name in sockets:
+            return sockets[name]
+
+        raise FatalStartupConfigurationError(missing_entry=f"socket with alias `{name}`")
+
+    def input_socket(self, name: str) -> InputSocket:
+        """
+        Retrieve an input socket if it exists.
+        """
+        return self._try_get_socket(name, self._input_sockets)
+
+    def output_socket(self, name: str) -> OutputSocket:
+        """
+        Retrieve an output socket if it exists.
+        """
+        return self._try_get_socket(name, self._output_sockets)
+
+    def with_inputs(self, new_or_updated: list[InputSocket]) -> Self:
+        """
+        Adds or updates existing input sockets.
+        """
+        for socket in new_or_updated:
+            self._input_sockets[socket.alias] = socket
+
+        return self
+
+    def with_outputs(self, new_or_updated: list[OutputSocket]) -> Self:
+        """
+        Adds or updates existing output sockets.
+        """
+        for socket in new_or_updated:
+            self._output_sockets[socket.alias] = socket
+
+        return self
+
+    @classmethod
+    def empty(cls) -> Self:
+        """
+        Returns an empty SocketCollection with no sockets.
+        :return:
+        """
+        return cls(input_sockets=[], output_sockets=[])
+
+    @classmethod
+    def from_dynaconf(
+        cls, input_sockets: list[dynaconf.utils.boxing.DynaBox], output_sockets: list[dynaconf.utils.boxing.DynaBox]
+    ) -> Self:
+        """
+        Creates a SocketCollection from a Dynaconf entry list
+        """
+        return cls(
+            input_sockets=[InputSocket.from_dict(socket_dict) for socket_dict in input_sockets],
+            output_sockets=[OutputSocket.from_dict(socket_dict) for socket_dict in output_sockets],
+        )
+
+
+@final
+@warnings.deprecated("This module is deprecated and will be removed in 1.7. Use SocketCollection instead.")
 class ExternalSocketProvider:
     """
     Wraps a socket collection
@@ -66,14 +155,6 @@ class ExternalSocketProvider:
             return cls(*[DataSocket.from_dict(socket_dict) for socket_dict in sockets_list])
 
         raise FatalStartupConfigurationError(f"Unknown type for input sockets: {type(sockets_list)}")
-
-    def merge_sockets(self, sockets: list[DataSocket]) -> Self:
-        """
-        Adds new sockets into existing sockets and updates sockets with a matching alias
-        """
-        for socket in sockets:
-            self._sockets[socket.alias] = socket
-        return self
 
     @classmethod
     def empty(cls) -> Self:

--- a/nexus_client_sdk/nexus/abstractions/socket_provider.py
+++ b/nexus_client_sdk/nexus/abstractions/socket_provider.py
@@ -67,6 +67,14 @@ class ExternalSocketProvider:
 
         raise FatalStartupConfigurationError(f"Unknown type for input sockets: {type(sockets_list)}")
 
+    def merge_sockets(self, sockets: list[DataSocket]) -> Self:
+        """
+        Adds new sockets into existing sockets and updates sockets with a matching alias
+        """
+        for socket in sockets:
+            self._sockets[socket.alias] = socket
+        return self
+
     @classmethod
     def empty(cls) -> Self:
         """

--- a/nexus_client_sdk/nexus/configurations/algorithm_configuration.py
+++ b/nexus_client_sdk/nexus/configurations/algorithm_configuration.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Self
 
 from dataclasses_json import DataClassJsonMixin
+import warnings
 
 
 #  Copyright (c) 2023-2026. ECCO Data & AI and other project contributors.
@@ -25,6 +26,9 @@ from dataclasses_json import DataClassJsonMixin
 
 
 @dataclass
+@warnings.deprecated(
+    "Legacy configuration will be removed in 1.7. Please migrate your custom configurations to Dynacof TOML files."
+)
 class NexusConfiguration(DataClassJsonMixin, ABC):
     """
     Base class for algorithm configurations

--- a/nexus_client_sdk/nexus/configurations/algorithm_configuration.py
+++ b/nexus_client_sdk/nexus/configurations/algorithm_configuration.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Self
 
 from dataclasses_json import DataClassJsonMixin
-import warnings
+from typing_extensions import deprecated
 
 
 #  Copyright (c) 2023-2026. ECCO Data & AI and other project contributors.
@@ -26,7 +26,7 @@ import warnings
 
 
 @dataclass
-@warnings.deprecated(
+@deprecated(
     "Legacy configuration will be removed in 1.7. Please migrate your custom configurations to Dynacof TOML files."
 )
 class NexusConfiguration(DataClassJsonMixin, ABC):

--- a/nexus_client_sdk/nexus/core/app_bootstrap.py
+++ b/nexus_client_sdk/nexus/core/app_bootstrap.py
@@ -6,12 +6,14 @@ from typing import final, Callable
 from adapta.logs import LoggerInterface
 from adapta.metrics import MetricsProvider
 from adapta.metrics.providers.void_provider import VoidMetricsProvider
+from adapta.process_communication import DataSocket
 from adapta.storage.blob.base import StorageClient
 from injector import Injector, Module, singleton
 
 from nexus_client_sdk.models.access_token import AccessToken
 from nexus_client_sdk.nexus.abstractions.logger_factory import BootstrapLoggerFactory, LoggerFactory
 from nexus_client_sdk.nexus.abstractions.metrics_provider_factory import MetricsProviderFactory
+from nexus_client_sdk.nexus.abstractions.socket_provider import ExternalSocketProvider
 from nexus_client_sdk.nexus.algorithms import BaselineAlgorithm
 from nexus_client_sdk.nexus.async_extensions.nexus_receiver_async_client import NexusReceiverAsyncClient
 from nexus_client_sdk.nexus.async_extensions.nexus_scheduler_async_client import NexusSchedulerAsyncClient
@@ -30,7 +32,7 @@ from nexus_client_sdk.nexus.core.app_dependencies import (
 from nexus_client_sdk.nexus.core.serializers import TelemetrySerializer
 from nexus_client_sdk.nexus.exceptions.startup_error import FatalStartupConfigurationError
 from nexus_client_sdk.nexus.input.command_line import NexusDefaultArguments
-from nexus_client_sdk.nexus.input.payload_reader import AlgorithmPayload, AlgorithmPayloadReader
+from nexus_client_sdk.nexus.input.payload_reader import AlgorithmPayload, AlgorithmPayloadReader, SocketOverridePayload
 from nexus_client_sdk.nexus.telemetry.payload_recorder import (
     PayloadTelemetry,
     FailedPayloadRecorder,
@@ -101,6 +103,7 @@ class NexusBootstrapper:
         # algorithm loading
         self._algorithm_classes: set[type[BaselineAlgorithm]] = set()
         self._algorithm_resolvers: list[Callable[[AlgorithmPayload], str]] = []
+        self._default_config = NEXUS_FRAMEWORK_CONFIGURATION.default
 
     async def _get_payload(
         self, payload_type: type[AlgorithmPayload], save_content: bool
@@ -142,6 +145,15 @@ class NexusBootstrapper:
         Resolves algorithm classes based on the payload received. Resolver must return a fully qualified import name for the algorithm class.
         """
         self._algorithm_resolvers.append(resolver)
+
+    def _load_socket_provider(self) -> ExternalSocketProvider:
+        base_provider = ExternalSocketProvider.empty()
+        if self._default_config.inputs.sockets and len(self._default_config.inputs.sockets) > 0:
+            base_provider = base_provider.merge_sockets(
+                [DataSocket.from_dict(socket_dict) for socket_dict in self._default_config.inputs.sockets]
+            )
+
+        return base_provider
 
     def _load_additional_modules(self):
         for additional_module in NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.additional_modules:
@@ -256,6 +268,7 @@ class NexusBootstrapper:
             app_injector = extension(app_injector)
 
         payload_read_results: dict[str, AlgorithmPayloadReader] = {}
+        socket_provider = self._load_socket_provider()
 
         for payload_type in self._payload_types:
             payload, reader = await self._get_payload(
@@ -272,6 +285,18 @@ class NexusBootstrapper:
             if payload is not None:
                 for resolver in self._algorithm_resolvers:
                     self._load_algorithm(resolver(payload))
+
+                if isinstance(payload, SocketOverridePayload):
+                    socket_provider = socket_provider.merge_sockets(payload.input_sockets or []).merge_sockets(
+                        payload.output_sockets or []
+                    )
+
+        # bind fully configured socket provider instance
+        app_injector.binder.bind(
+            socket_provider.__class__,
+            to=socket_provider,
+            scope=singleton,
+        )
 
         logger_factory = LoggerFactory(
             fixed_template=logger_fixed_template,

--- a/nexus_client_sdk/nexus/core/app_bootstrap.py
+++ b/nexus_client_sdk/nexus/core/app_bootstrap.py
@@ -102,7 +102,6 @@ class NexusBootstrapper:
         # algorithm loading
         self._algorithm_classes: set[type[BaselineAlgorithm]] = set()
         self._algorithm_resolvers: list[Callable[[AlgorithmPayload], str]] = []
-        self._default_config = NEXUS_FRAMEWORK_CONFIGURATION.default
 
     async def _get_payload(
         self, payload_type: type[AlgorithmPayload], save_content: bool
@@ -147,13 +146,25 @@ class NexusBootstrapper:
 
     def _load_data_sockets(self) -> SocketCollection:
         base_collection = SocketCollection.empty()
-        if self._default_config.inputs.sockets and len(self._default_config.inputs.sockets) > 0:
+        if (
+            NEXUS_FRAMEWORK_CONFIGURATION.default.inputs.sockets
+            and len(NEXUS_FRAMEWORK_CONFIGURATION.default.inputs.sockets) > 0
+        ):
             base_collection = base_collection.with_inputs(
-                [InputSocket.from_dict(socket_dict) for socket_dict in self._default_config.inputs.sockets]
+                [
+                    InputSocket.from_dict(socket_dict)
+                    for socket_dict in NEXUS_FRAMEWORK_CONFIGURATION.default.inputs.sockets
+                ]
             )
-        if self._default_config.outputs.sockets and len(self._default_config.outputs.sockets) > 0:
+        if (
+            "outputs" in NEXUS_FRAMEWORK_CONFIGURATION.default
+            and len(NEXUS_FRAMEWORK_CONFIGURATION.default.outputs.sockets) > 0
+        ):
             base_collection = base_collection.with_outputs(
-                [OutputSocket.from_dict(socket_dict) for socket_dict in self._default_config.outputs.sockets]
+                [
+                    OutputSocket.from_dict(socket_dict)
+                    for socket_dict in NEXUS_FRAMEWORK_CONFIGURATION.default.outputs.sockets
+                ]
             )
 
         return base_collection

--- a/nexus_client_sdk/nexus/core/app_bootstrap.py
+++ b/nexus_client_sdk/nexus/core/app_bootstrap.py
@@ -6,14 +6,13 @@ from typing import final, Callable
 from adapta.logs import LoggerInterface
 from adapta.metrics import MetricsProvider
 from adapta.metrics.providers.void_provider import VoidMetricsProvider
-from adapta.process_communication import DataSocket
 from adapta.storage.blob.base import StorageClient
 from injector import Injector, Module, singleton
 
 from nexus_client_sdk.models.access_token import AccessToken
 from nexus_client_sdk.nexus.abstractions.logger_factory import BootstrapLoggerFactory, LoggerFactory
 from nexus_client_sdk.nexus.abstractions.metrics_provider_factory import MetricsProviderFactory
-from nexus_client_sdk.nexus.abstractions.socket_provider import ExternalSocketProvider
+from nexus_client_sdk.nexus.abstractions.socket_provider import SocketCollection, InputSocket, OutputSocket
 from nexus_client_sdk.nexus.algorithms import BaselineAlgorithm
 from nexus_client_sdk.nexus.async_extensions.nexus_receiver_async_client import NexusReceiverAsyncClient
 from nexus_client_sdk.nexus.async_extensions.nexus_scheduler_async_client import NexusSchedulerAsyncClient
@@ -146,14 +145,18 @@ class NexusBootstrapper:
         """
         self._algorithm_resolvers.append(resolver)
 
-    def _load_socket_provider(self) -> ExternalSocketProvider:
-        base_provider = ExternalSocketProvider.empty()
+    def _load_data_sockets(self) -> SocketCollection:
+        base_collection = SocketCollection.empty()
         if self._default_config.inputs.sockets and len(self._default_config.inputs.sockets) > 0:
-            base_provider = base_provider.merge_sockets(
-                [DataSocket.from_dict(socket_dict) for socket_dict in self._default_config.inputs.sockets]
+            base_collection = base_collection.with_inputs(
+                [InputSocket.from_dict(socket_dict) for socket_dict in self._default_config.inputs.sockets]
+            )
+        if self._default_config.outputs.sockets and len(self._default_config.outputs.sockets) > 0:
+            base_collection = base_collection.with_outputs(
+                [OutputSocket.from_dict(socket_dict) for socket_dict in self._default_config.outputs.sockets]
             )
 
-        return base_provider
+        return base_collection
 
     def _load_additional_modules(self):
         for additional_module in NEXUS_FRAMEWORK_CONFIGURATION.default.runtime.additional_modules:
@@ -268,7 +271,7 @@ class NexusBootstrapper:
             app_injector = extension(app_injector)
 
         payload_read_results: dict[str, AlgorithmPayloadReader] = {}
-        socket_provider = self._load_socket_provider()
+        socket_collection = self._load_data_sockets()
 
         for payload_type in self._payload_types:
             payload, reader = await self._get_payload(
@@ -287,14 +290,14 @@ class NexusBootstrapper:
                     self._load_algorithm(resolver(payload))
 
                 if isinstance(payload, SocketOverridePayload):
-                    socket_provider = socket_provider.merge_sockets(payload.input_sockets or []).merge_sockets(
+                    socket_collection = socket_collection.with_inputs(payload.input_sockets or []).with_outputs(
                         payload.output_sockets or []
                     )
 
-        # bind fully configured socket provider instance
+        # bind fully configured socket collection instance
         app_injector.binder.bind(
-            socket_provider.__class__,
-            to=socket_provider,
+            socket_collection.__class__,
+            to=socket_collection,
             scope=singleton,
         )
 

--- a/nexus_client_sdk/nexus/input/payload_reader.py
+++ b/nexus_client_sdk/nexus/input/payload_reader.py
@@ -22,6 +22,7 @@ from functools import partial
 from pydoc import locate
 from typing import final
 
+from adapta.process_communication import DataSocket
 from adapta.utils import session_with_retries
 
 from dataclasses_json import DataClassJsonMixin
@@ -43,6 +44,16 @@ class AlgorithmPayload(DataClassJsonMixin):
 
     def __post_init__(self):
         self.validate()
+
+
+@dataclass
+class SocketOverridePayload(AlgorithmPayload):
+    """
+    Algorithm payload that may provide data socket overrides
+    """
+
+    input_sockets: list[DataSocket] | None = None
+    output_sockets: list[DataSocket] | None = None
 
 
 @dataclass

--- a/nexus_client_sdk/nexus/input/payload_reader.py
+++ b/nexus_client_sdk/nexus/input/payload_reader.py
@@ -16,17 +16,16 @@
 #  limitations under the License.
 #
 
-from dataclasses import dataclass
 import base64
+from dataclasses import dataclass
 from functools import partial
 from pydoc import locate
 from typing import final
 
-from adapta.process_communication import DataSocket
 from adapta.utils import session_with_retries
-
 from dataclasses_json import DataClassJsonMixin
 
+from nexus_client_sdk.nexus.abstractions.socket_provider import InputSocket, OutputSocket
 from nexus_client_sdk.nexus.async_extensions.async_exec import run_blocking
 from nexus_client_sdk.nexus.exceptions.startup_error import FatalStartupConfigurationError
 
@@ -52,8 +51,8 @@ class SocketOverridePayload(AlgorithmPayload):
     Algorithm payload that may provide data socket overrides
     """
 
-    input_sockets: list[DataSocket] | None = None
-    output_sockets: list[DataSocket] | None = None
+    input_sockets: list[InputSocket] | None = None
+    output_sockets: list[OutputSocket] | None = None
 
 
 @dataclass

--- a/nexus_client_sdk/nexus/input/payload_reader.py
+++ b/nexus_client_sdk/nexus/input/payload_reader.py
@@ -51,8 +51,8 @@ class SocketOverridePayload(AlgorithmPayload):
     Algorithm payload that may provide data socket overrides
     """
 
-    input_sockets: list[InputSocket] | None = None
-    output_sockets: list[OutputSocket] | None = None
+    input_sockets: list[InputSocket] | None
+    output_sockets: list[OutputSocket] | None
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,10 +18,11 @@ from dataclasses_json import DataClassJsonMixin
 from nexus_client_sdk.clients.nexus_receiver_client import NexusReceiverClient
 from nexus_client_sdk.clients.nexus_scheduler_client import NexusSchedulerClient
 from nexus_client_sdk.models.access_token import AccessToken
+from nexus_client_sdk.nexus.abstractions.socket_provider import InputSocket
 from nexus_client_sdk.nexus.async_extensions.nexus_receiver_async_client import NexusReceiverAsyncClient
 from nexus_client_sdk.nexus.async_extensions.nexus_scheduler_async_client import NexusSchedulerAsyncClient
 from nexus_client_sdk.nexus.configurations.algorithm_configuration import NexusConfiguration
-from nexus_client_sdk.nexus.input.payload_reader import AlgorithmPayload
+from nexus_client_sdk.nexus.input.payload_reader import AlgorithmPayload, SocketOverridePayload
 from nexus_client_sdk.testing import generate_payload_url
 
 
@@ -42,7 +43,7 @@ class TestEnum(Enum):
 
 
 @dataclass
-class TestAlgorithmPayload(AlgorithmPayload, DataClassJsonMixin):
+class TestAlgorithmPayload(SocketOverridePayload, DataClassJsonMixin):
     x: list[int]
     y: list[int]
     z: list[int]
@@ -149,6 +150,8 @@ def payloads(
             z=_rand_range(10),
             enum_value=random.choice(list(TestEnum)),
             alg_class="tests.sample_algorithm.sample_main.TestAlgorithm",
+            input_sockets=[InputSocket(alias="test", data_path="file:///tmp/test", data_format="text")],
+            output_sockets=[],
         )
         for _ in range(10)
     ]
@@ -174,6 +177,8 @@ def negative_z_payload() -> tuple[str, str]:
             z=[0, -1, 10],
             enum_value=TestEnum.A,
             alg_class="tests.sample_algorithm.sample_main.TestAlgorithm",
+            input_sockets=[InputSocket(alias="test", data_path="file:///tmp/test", data_format="text")],
+            output_sockets=[],
         ),
         S3StorageClient.for_storage_path(upload_path.to_hdfs_path()),
     )

--- a/tests/sample_algorithm/sample_main.py
+++ b/tests/sample_algorithm/sample_main.py
@@ -14,15 +14,14 @@ from nexus_client_sdk.nexus.abstractions.logger_factory import LoggerFactory
 from nexus_client_sdk.nexus.abstractions.nexus_object import AlgorithmResult
 from nexus_client_sdk.nexus.abstractions.socket_provider import (
     ExternalSocketProvider,
+    SocketCollection,
 )
-from nexus_client_sdk.nexus.core.app_core import Nexus
 from nexus_client_sdk.nexus.algorithms import MinimalisticAlgorithm
+from nexus_client_sdk.nexus.core.app_core import Nexus
 from nexus_client_sdk.nexus.core.serializers import TelemetrySerializer
 from nexus_client_sdk.nexus.exceptions import FatalNexusError
 from nexus_client_sdk.nexus.input import InputReader, InputProcessor
 from nexus_client_sdk.nexus.input.command_line import NexusDefaultArguments
-from nexus_client_sdk.nexus.input.payload_reader import AlgorithmPayload
-
 from nexus_client_sdk.nexus.telemetry.user_telemetry_recorder import (
     UserTelemetryRecorder,
     UserTelemetry,
@@ -49,7 +48,7 @@ class XYSampleReader(InputReader[TestAlgorithmPayload, pandas.DataFrame]):
         metrics_provider: MetricsProvider,
         logger_factory: LoggerFactory,
         payload: TestAlgorithmPayload,
-        _: ExternalSocketProvider,
+        socket_collection: SocketCollection,
         *readers: "InputReader",
         cache: InputCache
     ):
@@ -62,12 +61,16 @@ class XYSampleReader(InputReader[TestAlgorithmPayload, pandas.DataFrame]):
             cache=cache,
             *readers,
         )
+        self._socket_collection = socket_collection
 
     async def _read_input(self, **_) -> pandas.DataFrame:
         self._logger.info(
             "Payload: {payload}",
             payload=self._payload.to_json(),
         )
+        assert (
+            self._socket_collection.input_socket("test").data_format == "text"
+        ), "Unexpected data format for socket 'test'"
         return pandas.DataFrame({"x": self._payload.x, "y": self._payload.y})
 
 


### PR DESCRIPTION
Closes #218 

This pull request introduces a new service for managing input and output data sockets and integrates its provisioning into a bootstrap process.

### Data Socket Enhancements

* Introduced `InputSocket`, `OutputSocket` to allow distinguishing read-only and write-only sockets.
* Introduced `SocketCollection` as a central access point for all sockets.
* Marked the legacy `ExternalSocketProvider` as deprecated in favor of `SocketCollection`.

### Payload and Configuration Modernization

* Added `SocketOverridePayload` to `payload_reader.py`, allowing algorithm payloads to specify custom input/output sockets. 
* Marked the legacy `NexusConfiguration` as deprecated, encouraging migration to TOML-based configuration files.

### Application Bootstrap Logic

* Added loading sockets from configuration and then merging them with payload-provided sockets when present. The fully configured `SocketCollection` is afterwards added to the DI container.

### Test and Example Updates

* Updated test payloads and the sample algorithm to use `SocketOverridePayload` and `SocketCollection`, demonstrating the new socket override and lookup mechanisms. Assertions ensure correct socket configuration in tests.